### PR TITLE
Fix: "Bug: After uploading an attachment I can't click on it until I refresh the page"

### DIFF
--- a/workflow/static/js/edit_job_form_autosave.js
+++ b/workflow/static/js/edit_job_form_autosave.js
@@ -496,7 +496,8 @@ async function handlePDF(pdfBlob, mode, jobData) {
             formData.append('job_number', jobData.job_number);
             formData.append('files', new File([pdfBlob], `${jobData.name}.pdf`, { type: 'application/pdf' }));
 
-            fetch('/api/upload-job-files/', {
+            // The correct endpoint for job file POST/GET is just "/api/job-files" 
+            fetch('/api/job-files/', {
                 method: 'POST',
                 headers: { 'X-CSRFToken': getCsrfToken() },
                 body: formData

--- a/workflow/static/js/job_file_handling.js
+++ b/workflow/static/js/job_file_handling.js
@@ -45,7 +45,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function handleFiles(filesOrEvent) {
         const files = filesOrEvent.target?.files || filesOrEvent;
-        const jobNumber = document.getElementById('job_number_label').value;
 
         const formData = new FormData();
         formData.append('job_number', document.querySelector('[name="job_number"]').value);
@@ -79,6 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function updateFileList(newFiles) {
         if (!newFiles || newFiles.length === 0) return;
+        const jobNumber = document.getElementById('job_number_label').value;
 
         const list = document.querySelector('.job-files-list') || createNewFileList();
 

--- a/workflow/static/js/job_file_handling.js
+++ b/workflow/static/js/job_file_handling.js
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function updateFileList(newFiles) {
         if (!newFiles || newFiles.length === 0) return;
-        const jobNumber = document.getElementById('job_number_label').value;
+        const jobNumber = document.getElementById('job_number').value;
 
         const list = document.querySelector('.job-files-list') || createNewFileList();
 

--- a/workflow/static/js/job_file_handling.js
+++ b/workflow/static/js/job_file_handling.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function handleFiles(filesOrEvent) {
         const files = filesOrEvent.target?.files || filesOrEvent;
+        const jobNumber = document.getElementById('job_number_label').value;
 
         const formData = new FormData();
         formData.append('job_number', document.querySelector('[name="job_number"]').value);
@@ -85,7 +86,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const li = document.createElement('li');
             li.innerHTML = `
                 <div class="file-info">
-                    <a href="/api/job-files/${filename}" target="_blank">
+                    <a href="/api/job-files/${jobNumber}/${filename}" target="_blank">
                         ${filename}
                     </a>
                     <span class="timestamp">(Just uploaded)</span>

--- a/workflow/static/js/job_file_handling.js
+++ b/workflow/static/js/job_file_handling.js
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const li = document.createElement('li');
             li.innerHTML = `
                 <div class="file-info">
-                    <a href="/api/job-files/${jobNumber}/${filename}" target="_blank">
+                    <a href="/api/job-files/Job-${jobNumber}/${filename}" target="_blank">
                         ${filename}
                     </a>
                     <span class="timestamp">(Just uploaded)</span>

--- a/workflow/templates/jobs/edit_job_detail_section.html
+++ b/workflow/templates/jobs/edit_job_detail_section.html
@@ -41,7 +41,7 @@
             <input type="text" id="contact_phone" name="contact_phone" class="form-control autosave-input" value="{{ job.contact_phone|default_if_none:'' }}">
         </div>
         <div class="col-md-6">
-            <label for="job_number" class="form-label">Job Number</label>
+            <label id="job_number_label" for="job_number" class="form-label">Job Number</label>
             <input type="text" id="job_number" name="job_number" class="form-control autosave-input" value="{{ job.job_number }}" readonly>
         </div>
     </div>


### PR DESCRIPTION
# This PR focused on fixing the bug reported in this [Trello card](https://trello.com/c/jFXkvq60).

### The problem was related to the backend's GET endpoint structure for job files, which follows the following format:

```python
job_folder = os.path.join(settings.DROPBOX_WORKFLOW_FOLDER, f"Job-{job_number}")

file_path = os.path.join(job_folder, file.name)
``` 

### And the final path is: `/api/job-files/Job-{Job number here}/{File name here}`.

### But despite this, every time a new file was attached to a job, the frontend would omit the job number when constructing the href property of the anchor that redirected to the file in the system, which caused an HTTP 404 error.

<hr>

### Another unreported issue in Trello was also fixed in this PR and was related to an improper configuration of the Jobs Files API endpoint in the "upload" case of the switch statement in `edit_job_form_autosave.js`, which was also fixed.
