### PR TITLE
Timesheet Tweak

### DIFF
--- a/workflow/static/js/edit_job_form_autosave.js
+++ b/workflow/static/js/edit_job_form_autosave.js
@@ -257,7 +257,7 @@ async function exportJobToPDF(jobData) {
                     sectionContent.push({ text: grid.label, style: 'gridHeader', margin: [0, 10, 0, 5] });
     
                     const gridApi = gridInstance.api;
-                    const columns = gridApi.getColumnDefs().filter(col => col.headerName !== '' && col.headerName !== 'Actions');
+                    const columns = gridApi.getColumnDefs().filter(col => col.headerName !== '' && col.headerName !== 'Timesheet');
                     const headers = columns.map(col => col.headerName || 'N/A');
     
                     const rowData = [];
@@ -306,7 +306,7 @@ async function exportJobToPDF(jobData) {
             
                 const title = gridKey === "revenueTable" ? "Revenue Details" : "Costs Details";
                 const gridApi = grid.api;
-                const columns = gridApi.getColumnDefs().filter(col => col.headerName !== '' && col.headerName !== 'Actions');
+                const columns = gridApi.getColumnDefs().filter(col => col.headerName !== '' && col.headerName !== 'Timesheet');
                 const headers = columns.map(col => col.headerName || 'N/A');
             
                 const rowData = [];

--- a/workflow/static/js/edit_job_grid_logic.js
+++ b/workflow/static/js/edit_job_grid_logic.js
@@ -328,33 +328,64 @@ document.addEventListener('DOMContentLoaded', function () {
             {
                 headerName: 'Description',
                 field: 'description',
-                editable: true,
+                editable: true, 
                 flex: 2,
+                minWidth: 100,
                 cellRenderer: (params) => {
-                    // Render the description normally
-                    let content = `<span>${params.value || 'No Description'}</span>`;
-
-                    // Check if the 'link' field exists and append the action link
-                    if (params.data.link) {
+                    return `<span>${params.value || 'No Description'}</span>`;
+                }
+            },
+            {
+                headerName: 'Timesheet',
+                field: 'link',
+                width: 120,
+                minWidth: 100,
+                cellRenderer: (params) => {
+                    if (params.data.link && params.data.link.trim()) {                       
                         const linkLabel =
                             params.data.link === '/timesheets/overview/'
                                 ? ''
                                 : 'View Timesheet';
-                        content += ` | <a href='${params.data.link}' target='_blank' class='action-link'>${linkLabel}</a>`;
-                    }
 
-                    return content;
-                },
+                        if (linkLabel === '') {
+                            return `<span class="text-warning">Not found for this entry.</span>`;               
+                        }
+                        return `<a href='${params.data.link}' target='_blank' class='action-link'>${linkLabel}</a>`;
+                    }
+                    return 'Not found for this entry.';
+                }
             },
-            { headerName: 'Items', field: 'items', editable: true, valueParser: numberParser },
-            { headerName: 'Mins/Item', field: 'mins_per_item', editable: true, valueParser: numberParser },
-            { headerName: 'Total Minutes', field: 'total_minutes', editable: false },
+            { 
+                headerName: 'Items', 
+                field: 'items', 
+                editable: true, 
+                valueParser: numberParser,
+                minWidth: 80,
+                flex: 1
+            },
+            { 
+                headerName: 'Mins/Item', 
+                field: 'mins_per_item', 
+                editable: true, 
+                valueParser: numberParser,
+                minWidth: 90,
+                flex: 1
+            },
+            { 
+                headerName: 'Total Minutes', 
+                field: 'total_minutes', 
+                editable: false,
+                minWidth: 110,
+                flex: 1
+            },
             {
                 headerName: 'Wage Rate',
                 field: 'wage_rate',
                 editable: true,
                 valueParser: numberParser,
                 valueFormatter: currencyFormatter,
+                minWidth: 100,
+                flex: 1
             },
             {
                 headerName: 'Charge Rate',
@@ -362,8 +393,14 @@ document.addEventListener('DOMContentLoaded', function () {
                 editable: true,
                 valueParser: numberParser,
                 valueFormatter: currencyFormatter,
+                minWidth: 100,
+                flex: 1
             },
-            trashCanColumn,
+            {
+                ...trashCanColumn,
+                minWidth: 40,
+                maxWidth: 40
+            }
         ],
         rowData: [],
         context: { gridType: 'TimeTable' },

--- a/workflow/templates/base.html
+++ b/workflow/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="icon" href="{% static 'favicon.ico' %}" type="image/x-icon">
     <script src="{% static 'jquery/jquery.min.js' %}"></script>
     <link href="{% static 'bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
+    <link href="{% static 'bootstrap-icons/bootstrap-icons.css' %}" rel="stylesheet">
     {% block extra_css %}{% endblock %}
 </head>
 

--- a/workflow/templates/time_entries/timesheet_entry.html
+++ b/workflow/templates/time_entries/timesheet_entry.html
@@ -15,40 +15,47 @@
 <div class="container">
     <h2>Timesheet Entry - {{ staff_member.get_display_full_name }} - {{ timesheet_date }}</h2>
 
-    <div class="card border-light mb-3">
-        <div class="card-header bg-transparent">
-            <i class="bi bi-keyboard"></i> Keyboard Shortcuts
+    <div class="card mb-3">
+        <div class="card-header" data-bs-toggle="collapse" data-bs-target="#keyboardShortcuts"
+            aria-expanded="false" aria-controls="keyboardShortcuts" style="cursor: pointer;">
+            <div class="d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-keyboard"></i> Keyboard Shortcuts & <i class="bi bi-lightbulb"></i> Tips</span>
+                <i class="bi bi-chevron-down"></i>
+            </div>
         </div>
-        <div class="card-body">
-            <div class="row g-3">
-                <div class="col-md-6 col-lg-3">
-                    <div class="d-flex align-items-center">
-                        <span class="badge bg-light text-dark me-2">Shift + Enter</span>
-                        <small>Edit/Confirm cell changes</small>
+        <div id="keyboardShortcuts" class="collapse">
+            <div class="card-body bg-body-secondary">
+                <div class="row g-3">
+                    <div class="col-md-6 col-lg-3">
+                        <div class="d-flex align-items-center">
+                            <span class="badge bg-light text-dark me-2">Shift + Enter</span>
+                            <small>Edit/Confirm cell changes</small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-md-6 col-lg-3">
-                    <div class="d-flex align-items-center">
-                        <span class="badge bg-light text-dark me-2">Enter</span>
-                        <small>Add new row below</small>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="d-flex align-items-center">
+                            <span class="badge bg-light text-dark me-2">Enter</span>
+                            <small>Add new row below</small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-md-6 col-lg-3">
-                    <div class="d-flex align-items-center">
-                        <span class="badge bg-light text-dark me-2">Esc</span>
-                        <small>Cancel editing</small>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="d-flex align-items-center">
+                            <span class="badge bg-light text-dark me-2">Esc</span>
+                            <small>Cancel editing</small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-md-6 col-lg-3">
-                    <div class="d-flex align-items-center">
-                        <span class="badge bg-light text-dark me-2">Tab</span>
-                        <small>Move to next cell</small>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="d-flex align-items-center">
+                            <span class="badge bg-light text-dark me-2">Tab</span>
+                            <small>Move to next cell</small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-12">
-                    <small class="text-muted">
-                        <i class="bi bi-info-circle"></i> Use arrow keys to navigate between cells and within the jobs dropdown list
-                    </small>
+                    <div class="col-12">
+                        <small class="text-muted">
+                            <i class="bi bi-info-circle"></i> Use arrow keys to navigate between cells and within the
+                            jobs dropdown list
+                        </small>
+                    </div>
                 </div>
             </div>
         </div>
@@ -60,14 +67,15 @@
 
     <div class="header-actions d-flex justify-content-between mt-3 mb-2">
         <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=prev_staff.id %}" class="btn btn-primary">
-            {{ prev_staff.name }} <- Previous staff 
-        </a>
-        <a href="{% url 'timesheet_daily_view' date=timesheet_date %}" class="btn btn-secondary align-self-center">
-            Back to Daily Overview
-        </a>
-        <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=next_staff.id %}" class="btn btn-primary">
-            Next staff -> {{ next_staff.name }}
-        </a>
+            {{ prev_staff.name }} <- Previous staff </a>
+                <a href="{% url 'timesheet_daily_view' date=timesheet_date %}"
+                    class="btn btn-secondary align-self-center">
+                    Back to Daily Overview
+                </a>
+                <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=next_staff.id %}"
+                    class="btn btn-primary">
+                    Next staff -> {{ next_staff.name }}
+                </a>
     </div>
 
     <!-- Messages will be loaded here -->

--- a/workflow/templates/time_entries/timesheet_entry.html
+++ b/workflow/templates/time_entries/timesheet_entry.html
@@ -7,7 +7,6 @@
 
 <!-- Bootstrap Icons and custom CSS classes -->
 <link rel="stylesheet" href="{% static 'css/timesheet-entry.css' %}">
-<link rel="stylesheet" href="{% static 'bootstrap-icons/bootstrap-icons.min.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/workflow/templates/time_entries/timesheet_entry.html
+++ b/workflow/templates/time_entries/timesheet_entry.html
@@ -56,19 +56,18 @@
     
     <!-- AG Grid will be initialized here -->
     <div id="timesheet-grid" class="ag-theme-alpine">
-    </div>    
+    </div>
 
     <div class="header-actions d-flex justify-content-between mt-3 mb-2">
         <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=prev_staff.id %}" class="btn btn-primary">
-            {{ prev_staff.get_display_full_name }} <- Previous staff </a>
-                <a href="{% url 'timesheet_daily_view' date=timesheet_date %}"
-                    class="btn btn-secondary align-self-center">
-                    Back to Daily Overview
-                </a>
-                <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=next_staff.id %}"
-                    class="btn btn-primary">
-                    Next staff -> {{ next_staff.get_display_full_name }}
-                </a>
+            {{ prev_staff.name }} <- Previous staff 
+        </a>
+        <a href="{% url 'timesheet_daily_view' date=timesheet_date %}" class="btn btn-secondary align-self-center">
+            Back to Daily Overview
+        </a>
+        <a href="{% url 'timesheet_entry' date=timesheet_date staff_id=next_staff.id %}" class="btn btn-primary">
+            Next staff -> {{ next_staff.name }}
+        </a>
     </div>
 
     <!-- Messages will be loaded here -->

--- a/workflow/templates/time_entries/timesheet_overview.html
+++ b/workflow/templates/time_entries/timesheet_overview.html
@@ -36,17 +36,33 @@
     </div>
 
     <div class="row align-items-center mb-4">
-        <div class="col-md-6 text-start">
-            <h1>
+        <div class="col-md-12 text-center">
+            <h1 class="mb-3">
                 Timesheet Overview
             </h1>
-            <button class="btn btn-outline-primary rounded-2 p-2" data-bs-toggle="modal"
-                data-bs-target="#weekPickerModal">
-                Change Week
-            </button>
-            <span id="current-week-display" class="font-monospace bold p-2 bg-primary-subtle d-inline-block rounded-2">
-                {{ week_days.0|date:"jS F Y" }} - {{ week_days|last|date:"jS F Y" }}
-            </span>
+            <div class="d-flex justify-content-center align-items-center flex-wrap gap-2">
+                <div class="btn-group" role="group" aria-label="Week navigation" style="width: 450px;">
+                    <a href="{{ prev_week_url }}"
+                        class="btn btn-outline-primary rounded-start-2 d-flex align-items-center justify-content-center"
+                        style="width: 150px; height: 42px;">
+                        <i class="bi bi-chevron-left"></i> Previous Week
+                    </a>
+                    <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#weekPickerModal"
+                        style="width: 150px; height: 42px;">
+                        Change Week
+                    </button>
+                    <a href="{{ next_week_url }}"
+                        class="btn btn-outline-primary rounded-end-2 d-flex align-items-center justify-content-center"
+                        style="width: 150px; height: 42px;">
+                        Next Week <i class="bi bi-chevron-right"></i>
+                    </a>
+                </div>
+                <span id="current-week-display"
+                    class="font-monospace bold p-2 bg-primary-subtle d-inline-block rounded-2"
+                    style="width: 450px; font-size: 1.15rem; font-weight: bold; height: 42px;">
+                    {{ week_days.0|date:"jS F Y" }} - {{ week_days|last|date:"jS F Y" }}
+                </span>
+            </div>
         </div>
     </div>
 
@@ -75,7 +91,7 @@
             </div>
             <div class="card-body">
                 <div class="d-flex align-items-center gap-2">
-                    <button class="btn btn-lg btn-outline-success mt-2" data-bs-toggle="modal"
+                    <button class="btn btn-outline-success mt-2" data-bs-toggle="modal"
                         data-bs-target="#paidAbsenceModal">
                         Add Paid Absence
                     </button>
@@ -120,7 +136,7 @@
             <div class="container">
                 <div class="text-center">
                     <div class="d-flex justify-content-center overflow-auto">
-                        <div class="w-100">
+                        <div class="w-150">
                             {{ graphic|safe }}
                         </div>
                     </div>

--- a/workflow/views/time_entry_view.py
+++ b/workflow/views/time_entry_view.py
@@ -4,12 +4,15 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 
 from django.core.serializers.json import DjangoJSONEncoder
+from django.core.cache import cache
 from django.template.loader import render_to_string
 from django.http import JsonResponse, Http404
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django.views.generic import TemplateView
 from django.contrib import messages
+from django.db.models import Value, Func, IntegerField, CharField
+from django.db.models.functions import Coalesce, Concat
 
 from workflow.enums import RateType
 from workflow.models import Job, JobPricing, Staff, TimeEntry
@@ -47,7 +50,8 @@ class TimesheetEntryView(TemplateView):
 
     template_name = "time_entries/timesheet_entry.html"
 
-    # Excluding app users ID's to avoid them being loaded in timesheet views because they do not have entries (Valerie and Corrin included as they are not supposed to enter hours)
+    # Excluding app users ID's to avoid them being loaded in timesheet views because they do not have entries 
+    # (Valerie and Corrin included as they are not supposed to enter hours)
     EXCLUDED_STAFF_IDS = [
         "a9bd99fa-c9fb-43e3-8b25-578c35b56fa6",
         "b50dd08a-58ce-4a6c-b41e-c3b71ed1d402",
@@ -103,65 +107,82 @@ class TimesheetEntryView(TemplateView):
             target_date = datetime.strptime(date, "%Y-%m-%d").date()
         except ValueError:
             raise ValueError("Invalid date format. Expected YYYY-MM-DD.")
-
+        
         if staff_id in self.EXCLUDED_STAFF_IDS:
             raise PermissionError("Access denied for this staff member")
-
+        
         try:
             staff_member = Staff.objects.get(id=staff_id)
         except Staff.DoesNotExist:
             raise Http404("Staff member not found")
-
-        time_entries = TimeEntry.objects.filter(
-            date=target_date, staff=staff_member
-        ).select_related("job_pricing__latest_reality_for_job__client")
-
-        scheduled_hours = float(staff_member.get_scheduled_hours(target_date))
-
-        staff_data = {
-            "id": staff_member.id,
-            "name": staff_member.get_display_full_name(),
-            "wage_rate": staff_member.wage_rate,
-            "scheduled_hours": scheduled_hours,
+        
+        all_staff = self._get_staff_navigation_list(self.EXCLUDED_STAFF_IDS)
+        
+        # Locate the index of the current staff.
+        staff_index = next((index for index, s in enumerate(all_staff) if s["id"] == staff_id), None)
+        if staff_index is None:
+            raise Http404("Staff member not found in ordered list")
+        
+        # Compute circular navigation indexes.
+        next_index = (staff_index + 1) % len(all_staff)
+        prev_index = (staff_index - 1) % len(all_staff)
+        
+        next_staff = {
+            "id": all_staff[next_index]["id"],
+            "name": all_staff[next_index]["display_full_name"],
         }
+        prev_staff = {
+            "id": all_staff[prev_index]["id"],
+            "name": all_staff[prev_index]["display_full_name"],
+        }
+
+        time_entries = (
+            TimeEntry.objects.filter(date=target_date, staff_id=staff_id)
+            .select_related("job_pricing__latest_reality_for_job__client")
+            .values(
+                "id",
+                "job_pricing_id",
+                "job_pricing__job__job_number",
+                "job_pricing__job__name",
+                "job_pricing__job__client__name",
+                "description",
+                "hours",
+                "wage_rate_multiplier",
+                "is_billable",
+                "note",
+            )
+        )
 
         timesheet_data = [
             {
-                "id": str(entry.id),
-                "job_pricing_id": entry.job_pricing_id,
-                "job_number": entry.job_pricing.job.job_number,
-                "job_name": entry.job_pricing.job.name,
-                "client_name": (
-                    entry.job_pricing.job.client.name
-                    if entry.job_pricing.job.client
-                    else "No client!?"
-                ),
-                "description": entry.description or "",
-                "hours": float(
-                    entry.hours
-                ),  # Implicitly assumes one item, which is correct for reality
-                "rate_multiplier": float(entry.wage_rate_multiplier),
-                "is_billable": entry.is_billable,
-                "notes": entry.note or "",
+                "id": str(entry["id"]),
+                "job_pricing_id": entry["job_pricing_id"],
+                "job_number": entry["job_pricing__job__job_number"],
+                "job_name": entry["job_pricing__job__name"],
+                "client_name": entry["job_pricing__job__client__name"] or "No client!?",
+                "description": entry["description"] or "",
+                "hours": float(entry["hours"]),
+                "rate_multiplier": float(entry["wage_rate_multiplier"]),
+                "is_billable": entry["is_billable"],
+                "notes": entry["note"] or "",
                 "timesheet_date": target_date.strftime("%Y-%m-%d"),
-                "staff_id": staff_member.id,
-                "scheduled_hours": float(staff_member.get_scheduled_hours(target_date)),
             }
             for entry in time_entries
         ]
 
-        open_jobs = Job.objects.filter(
-            status__in=["quoting", "approved", "in_progress", "special"]
-        ).select_related("client")
+        open_jobs = (
+            Job.objects.filter(status__in=["quoting", "approved", "in_progress", "special"])
+            .select_related("client", "latest_estimate_pricing", "latest_reality_pricing")
+        )
 
         jobs_data = [
             {
                 "id": str(job.id),
                 "job_number": job.job_number,
                 "name": job.name,
-                "job_display_name": str(job),
-                "estimated_hours": job.latest_estimate_pricing.total_hours,
-                "hours_spent": job.latest_reality_pricing.total_hours,
+                "job_display_name": f"{job.job_number} - {job.name}",
+                "estimated_hours": job.latest_estimate_pricing.total_hours if job.latest_estimate_pricing else 0,
+                "hours_spent": job.latest_reality_pricing.total_hours if job.latest_reality_pricing else 0,
                 "client_name": job.client.name if job.client else "NO CLIENT!?",
                 "charge_out_rate": float(job.charge_out_rate),
                 "job_status": job.status,
@@ -172,39 +193,18 @@ class TimesheetEntryView(TemplateView):
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
             return JsonResponse({"time_entries": timesheet_data, "jobs": jobs_data})
 
-        next_staff = (
-            Staff.objects.exclude(id__in=self.EXCLUDED_STAFF_IDS)
-            .filter(id__gt=staff_member.id)
-            .order_by("id")
-            .first()
-        )
-
-        if not next_staff:
-            next_staff = (
-                Staff.objects.exclude(id__in=self.EXCLUDED_STAFF_IDS)
-                .order_by("id")
-                .first()
-            )
-
-        prev_staff = (
-            Staff.objects.exclude(id__in=self.EXCLUDED_STAFF_IDS)
-            .filter(id__lt=staff_member.id)
-            .order_by("-id")
-            .first()
-        )
-
-        if not prev_staff:
-            prev_staff = (
-                Staff.objects.exclude(id__in=self.EXCLUDED_STAFF_IDS)
-                .order_by("-id")
-                .first()
-            )
-
         context = {
             "staff_member": staff_member,
-            "staff_member_json": json.dumps(staff_data, cls=DjangoJSONEncoder),
+            "staff_member_json": json.dumps(
+                {
+                    "id": staff_member.id,
+                    "name": f"{staff_member.first_name} {staff_member.last_name}",
+                    "wage_rate": staff_member.wage_rate,
+                    "scheduled_hours": float(staff_member.get_scheduled_hours(target_date)),
+                },
+                cls=DjangoJSONEncoder,
+            ),
             "timesheet_date": target_date.strftime("%Y-%m-%d"),
-            "scheduled_hours": scheduled_hours,
             "timesheet_entries_json": json.dumps(timesheet_data, cls=DjangoJSONEncoder),
             "jobs_json": json.dumps(jobs_data, cls=DjangoJSONEncoder),
             "next_staff": next_staff,
@@ -212,6 +212,46 @@ class TimesheetEntryView(TemplateView):
         }
 
         return render(request, self.template_name, context)
+    
+    def _get_staff_navigation_list(self, excluded_ids, cache_timeout=3600):
+        """
+        Retrieves the ordered staff list for navigation, annotated with a computed display_full_name.
+        
+        Intention:
+        - Compute the display_first_name using only the first token of the preferred_name (or first_name).
+        - Concatenate it with the full last_name to get display_full_name.
+        - Order by display_full_name.
+        - Cache the resulting list to reduce database load if the staff list does not change frequently.
+        
+        Parameters:
+        - excluded_ids: List or set of staff IDs to exclude.
+        - cache_timeout (int): The time in seconds for which the result should be cached.
+        
+        Returns:
+        - A list of dictionaries with keys 'id' and 'display_full_name'.
+        """
+        cache_key = "staff_navigation_list"
+        staff_list = cache.get(cache_key)
+        if staff_list is None:
+            staff_queryset = (
+                Staff.objects.exclude(id__in=excluded_ids)
+                .annotate(
+                    display_first_name=Func(
+                        Coalesce('preferred_name', 'first_name'),
+                        Value(' '),
+                        Value(1, output_field=IntegerField()),
+                        function='substring_index',
+                        output_field=CharField()
+                    )
+                )
+                .annotate(
+                    display_full_name=Concat('display_first_name', Value(' '), 'last_name', output_field=CharField())
+                )
+                .order_by('display_full_name')
+            )
+            staff_list = list(staff_queryset.values("id", "display_full_name"))
+            cache.set(cache_key, staff_list, timeout=cache_timeout)
+        return staff_list
 
 
 @require_http_methods(["POST"])

--- a/workflow/views/time_overview_view.py
+++ b/workflow/views/time_overview_view.py
@@ -126,16 +126,20 @@ class TimesheetOverviewView(TemplateView):
             start_date: Date string in YYYY-MM-DD format
 
         Returns:
-            datetime.date object for start date or default date 7 days ago
+            datetime.date object for start date, defaulting to Monday of current week
         """
         if start_date:
             try:
                 return datetime.strptime(start_date, "%Y-%m-%d").date()
             except ValueError as e:
                 logger.warning(f"Invalid start date format: {str(e)}")
-                return timezone.now().date() - timezone.timedelta(days=7)
-        return timezone.now().date() - timezone.timedelta(days=7)
-
+                # Get Monday of current week
+                today = timezone.now().date()
+                return today - timezone.timedelta(days=today.weekday())
+        # Get Monday of current week if no start_date provided
+        today = timezone.now().date()
+        return today - timezone.timedelta(days=today.weekday())
+    
     def _get_week_days(self, start_date):
         """Generate list of weekdays from start date.
 


### PR DESCRIPTION
Hey. This PR focused on solving the following Trello cards:

- [Timesheet week should default to the current week](https://trello.com/c/9wY4uVav)
- [The ordering of staff should always be alphabetical. Test in timesheets](https://trello.com/c/KhHcqtgd)
- [Add a prev week/next week button to timesheet overview](https://trello.com/c/KhHcqtgd)
- [Move the view timesheet link](https://trello.com/c/XZRdmjAy)
- [Remove ALL vertical bars.](https://trello.com/c/JkEOT34q)

Also, other things were corrected/added too:

- Made the Tables on Edit job responsive by defining flex and min-width to their columns.
- Made the Keyboard Shortcuts section on Timesheet Entry page a toggable element.
- Optimized main DB queries on TimesheetEntryView to improve performance of the application

# ALL FUNCTIONALITIES OF TIMESHEETS WERE TESTED TO GUARANTEE PROPER USABILITY OF THE APPLICATION.
## ALL TESTS PASSED, AND ANYONE CAN CHECK THE SYSTEM STATUS ON https://workflow-app.ens.org, WHICH HAS A PROPER SETUP OF THE CURRENT BRANCH.