### PR TITLE
Fix: lack of pagination in Kanban

### DIFF
--- a/workflow/static/css/kanban.css
+++ b/workflow/static/css/kanban.css
@@ -92,23 +92,45 @@ body {
 
 
 .search-container {
-    padding: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 15px;
+    padding: 10px 20px;
     background-color: #f4f5f7;
     border-bottom: 1px solid #dfe1e6;
-    position: relative;
-    overflow: hidden; /* Clear floats */
 }
-#monthEndButton {
-    float: right; /* Ensure the button stays on the right */
+
+.job-controls {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.styled-select {
+    padding: 6px 12px;
+    font-size: 14px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    background-color: white;
+    cursor: pointer;
 }
 
 #search {
+    flex-grow: 1;
+    padding: 8px 12px;
+    border-radius: 5px;
+    border: 1px solid #dfe1e6;
     width: 100%;
     float: left;
     max-width: 300px;
-    padding: 8px;
-    border-radius: 3px;
-    border: 1px solid #dfe1e6;
+}
+
+#monthEndButton {
+    padding: 8px 12px;
+    font-size: 14px;
+    float: right; /* Ensure the button stays on the right */
 }
 
 .job-card-dragging {
@@ -144,4 +166,22 @@ body {
 .kanban-board::-webkit-scrollbar-track,
 .job-list::-webkit-scrollbar-track {
     background: #f4f5f7;
+}
+
+.load-more-container {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+}
+
+.left-container {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.left-container .btn {
+    max-width: fit-content;
+    white-space: nowrap;
 }

--- a/workflow/templates/jobs/kanban_board.html
+++ b/workflow/templates/jobs/kanban_board.html
@@ -8,42 +8,60 @@
 {% block content %}
 
 <div id="monthEndModal" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Select Jobs for Month-End Processing</h5>
-     
-        </div>
-        <div class="modal-body">
-          <form id="monthEndForm">
-            <label for="jobSelector">Jobs</label>
-            <select id="jobSelector" class="form-control" multiple>
-              {% for job in jobs %}
-                <option value="{{ job.id }}">{{ job.name }}</option>
-              {% endfor %}
-            </select>
-          </form>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" id="confirmMonthEnd" class="btn btn-primary">Process</button>
-        </div>
-     </div>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Select Jobs for Month-End Processing</h5>
+
+      </div>
+      <div class="modal-body">
+        <form id="monthEndForm">
+          <label for="jobSelector">Jobs</label>
+          <select id="jobSelector" class="form-control" multiple>
+            {% for job in jobs %}
+            <option value="{{ job.id }}">{{ job.name }}</option>
+            {% endfor %}
+          </select>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" id="confirmMonthEnd" class="btn btn-primary">Process</button>
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="search-container">
-    <input type="text" id="search" placeholder="Search jobs...">
+  <input type="text" id="search" class="form-control" placeholder="🔍 Search jobs...">
+
+  <div class="left-container">
     <button id="monthEndButton" class="btn btn-primary">Month End</button>
+    <div class="job-controls">
+      <label for="jobPageSize" class="form-label">Jobs per page:</label>
+      <select id="jobPageSize" class="form-select">
+        <option value="10">10</option>
+        <option value="20">20</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+      </select>
+    </div>
+  </div>
 </div>
 
 <div class="kanban-board">
-    {% for status_key, status_label in status_choices %}
-    <div id="{{ status_key }}" class="kanban-column">
-        <div class="column-header">{{ status_label }}</div>
-        <div class="job-list"></div>
-    </div>
-    {% endfor %}
+  {% for status_key, status_label in status_choices %}
+  <div id="{{ status_key }}" class="kanban-column">
+      <div class="column-header">{{ status_label }} (<span id="{{ status_key }}-count">0</span> of <span id="{{ status_key }}-total">0</span>)</div>
+      <div class="job-list"></div>
+      
+      <div id="{{ status_key }}-load-more-container" class="load-more-container mb-2" style="display: none;">
+          <button id="{{ status_key }}-load-more" class="load-more btn btn-secondary" data-status="{{ status_key }}">
+              Load More
+          </button>
+      </div>
+  </div>
+  {% endfor %}  
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Hey.

This PR focused on fixing the bug where only ten jobs were fetched to the kanban, which was preventing the users to search/view jobs that weren't loaded in the page.

Key changes:

- implement pagination and load more functionality for kanban board
- add search alert to inform users that search is limited to loaded jobs
- improve kanban board UI and UX
- add job controls for jobs per page

Tests were made (and can be checked) [here](https://workflow-app.ens.org).