### PR TITLE
Fix: job file duplication during creation of new Backup PDF (JobSummary)

### DIFF
--- a/workflow/static/js/edit_job_grid_logic.js
+++ b/workflow/static/js/edit_job_grid_logic.js
@@ -830,10 +830,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 deleteXeroDocument(jobId, 'invoice');
                 break;
 
-            case 'printJobButton':
-                handlePrintJob();
-                break;
-
             case 'acceptQuoteButton':
                 const currentDateTimeISO = new Date().toISOString();
                 document.getElementById('quote_acceptance_date_iso').value = currentDateTimeISO;


### PR DESCRIPTION
Hey.

Key changes:
- changed the filename of the backup PDF to "JobSummary" to match new standard
- refactor `handleClose()` to verify existence of the JobSummary file before creating it (to decide if PUT or POST)