### PR TITLE
Fix: trash can column not being rendered in Time Grids

### DIFF
--- a/workflow/static/js/edit_job_grid_logic.js
+++ b/workflow/static/js/edit_job_grid_logic.js
@@ -649,9 +649,11 @@ document.addEventListener('DOMContentLoaded', function () {
                                 col.cellRenderer = timeGridOptions.columnDefs.find(c => c.field === 'link').cellRenderer;
                             }
                         });
+                        specificGridOptions.columnDefs = specificGridOptions.columnDefs.filter(col => col.field !== '');
                         break;
                     }
-                    specificGridOptions = JSON.parse(JSON.stringify(timeGridOptions));
+                    specificGridOptions = { ...timeGridOptions }; // Now using shallow copying to keep the renderer functions
+                    
                     // Hide link column for estimate and quote sections
                     specificGridOptions.columnDefs = specificGridOptions.columnDefs.map(col => {
                         if (col.field === 'link') {


### PR DESCRIPTION
refactor(edit_job_grid_logic.js): improve grid options handling for estimate and quote sections

This commit improves the handling of grid options for the estimate and quote sections in `edit_job_grid_logic.js`.

- Uses shallow copying to keep the renderer functions.
- Filters out empty column definitions to prevent errors.