### PR TITLE
Remove description and refactor column alignment of simple grids

### DIFF
--- a/workflow/static/js/job/deserialize_job_pricing.js
+++ b/workflow/static/js/job/deserialize_job_pricing.js
@@ -167,7 +167,7 @@ function loadSimpleJobTime(entries) {
     const charge = parseFloat(entry.charge_out_rate) || 105;
     
     return {
-      description: entry.description,
+      description: '',
       hours: hours,
       cost_of_time: hours * wage,
       value_of_time: hours * charge,
@@ -179,7 +179,7 @@ function loadSimpleJobTime(entries) {
 
 function loadSimpleJobMaterial(entries) {
   return entries.map((entry) => ({
-    description: entry.description,
+    description: '',
     material_cost: entry.unit_cost * entry.quantity,
     retail_price: entry.unit_revenue * entry.quantity,
   }));
@@ -187,7 +187,7 @@ function loadSimpleJobMaterial(entries) {
 
 function loadSimpleJobAdjustment(entries) {
   return entries.map((entry) => ({
-    description: entry.description,
+    description: '',
     cost_adjustment: entry.cost_adjustment,
     price_adjustment: entry.price_adjustment,
   }));

--- a/workflow/static/js/job/grid/grid_options.js
+++ b/workflow/static/js/job/grid/grid_options.js
@@ -241,7 +241,7 @@ export function createAdvancedTimeGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "Description",
+        headerName: "Time Description",
         field: "description",
         editable: true,
         flex: 2,
@@ -348,7 +348,7 @@ export function createAdvancedMaterialsGridOptions(
         hide: true,
       },
       {
-        headerName: "Description",
+        headerName: "Material Description",
         field: "description",
         editable: true,
         flex: 2,
@@ -411,7 +411,7 @@ export function createAdvancedAdjustmentsGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "Description",
+        headerName: "Adjustment Description",
         field: "description",
         editable: true,
         flex: 2,
@@ -457,21 +457,23 @@ export function createSimpleTimeGridOptions(commonGridOptions, trashCanColumn) {
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "",
+        headerName: "Time Table",
         field: "description",
         editable: false,
         flex: 2,
-        maxWidth: 310
+        maxWidth: 155,
+        width: 155
       },
       {
         headerName: "Hours",
         field: "hours",
         editable: true,
         valueParser: numberParser,
-        maxWidth: 80,
+        maxWidth: 235,
+        width: 235,
       },
       {
-        headerName: "Cost of Time ($)",
+        headerName: "Cost ($)",
         field: "cost_of_time",
         editable: false,
         valueParser: numberParser,
@@ -479,7 +481,7 @@ export function createSimpleTimeGridOptions(commonGridOptions, trashCanColumn) {
         minWidth: 80,
       },
       {
-        headerName: "Value of Time ($)",
+        headerName: "Retail ($)",
         field: "value_of_time",
         editable: false,
         valueParser: numberParser,
@@ -514,7 +516,7 @@ export function createSimpleMaterialsGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "",
+        headerName: "Materials Table",
         field: "description",
         editable: false,
         flex: 2,
@@ -551,7 +553,7 @@ export function createSimpleAdjustmentsGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "",
+        headerName: "Adjustments Table",
         field: "description",
         editable: false,
         flex: 2,
@@ -587,7 +589,7 @@ export function createSimpleTotalsGridOptions(gridKey) {
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "",
+        headerName: "Totals Table",
         field: "section",
         editable: false,
         maxWidth: 395,

--- a/workflow/static/js/job/grid/grid_options.js
+++ b/workflow/static/js/job/grid/grid_options.js
@@ -457,9 +457,9 @@ export function createSimpleTimeGridOptions(commonGridOptions, trashCanColumn) {
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "Time Description",
+        headerName: "",
         field: "description",
-        editable: true,
+        editable: false,
         flex: 2,
         maxWidth: 310
       },
@@ -514,9 +514,9 @@ export function createSimpleMaterialsGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "Material Description",
+        headerName: "",
         field: "description",
-        editable: true,
+        editable: false,
         flex: 2,
         maxWidth: 390
       },
@@ -551,9 +551,9 @@ export function createSimpleAdjustmentsGridOptions(
     ...commonGridOptions,
     columnDefs: [
       {
-        headerName: "Adjustment Description",
+        headerName: "",
         field: "description",
-        editable: true,
+        editable: false,
         flex: 2,
         maxWidth: 390
       },


### PR DESCRIPTION
This PR focused on "removing" job descriptions by making their grid columns non-editable (in simple grids). Now descriptions aren't serialized anymore to simple grids and the column is empty (but still visible to the user to maintain the visual consistency and alignment to the total cost and value.

Changes to job descriptions:

* [`workflow/static/js/job/deserialize_job_pricing.js`](diffhunk://#diff-19a13567062e4cc378439521c71d16bf458a12497c4aa30be5d3f93e1fc994c8L170-R170): Set the `description` field to an empty string in the `loadSimpleJobTime`, `loadSimpleJobMaterial`, and `loadSimpleJobAdjustment` functions. [[1]](diffhunk://#diff-19a13567062e4cc378439521c71d16bf458a12497c4aa30be5d3f93e1fc994c8L170-R170) [[2]](diffhunk://#diff-19a13567062e4cc378439521c71d16bf458a12497c4aa30be5d3f93e1fc994c8L182-R190)

Changes to grid options:

* [`workflow/static/js/job/grid/grid_options.js`](diffhunk://#diff-f60040b787d51f26a192b748ebfbb5215a6fde0cfa1d92493678057465196684L460-R462): Updated the `headerName` to an empty string and set the `editable` property to `false` for the `description` field in the `createSimpleTimeGridOptions`, `createSimpleMaterialsGridOptions`, and `createSimpleAdjustmentsGridOptions` functions. [[1]](diffhunk://#diff-f60040b787d51f26a192b748ebfbb5215a6fde0cfa1d92493678057465196684L460-R462) [[2]](diffhunk://#diff-f60040b787d51f26a192b748ebfbb5215a6fde0cfa1d92493678057465196684L517-R519) [[3]](diffhunk://#diff-f60040b787d51f26a192b748ebfbb5215a6fde0cfa1d92493678057465196684L554-R556)