### PR TITLE
Fix: timesheets vanishing after going to related job 

### DIFF
--- a/workflow/models/time_entry.py
+++ b/workflow/models/time_entry.py
@@ -3,6 +3,7 @@ import uuid
 from decimal import Decimal
 
 from django.db import models
+from django.forms import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/workflow/static/js/job/edit_job_form_autosave.js
+++ b/workflow/static/js/job/edit_job_form_autosave.js
@@ -158,7 +158,9 @@ function collectGridData(section) {
 }
 
 function collectAdvancedGridData(section) {
-  const grids = ["TimeTable", "MaterialsTable", "AdjustmentsTable"];
+  const grids = section === "reality"
+    ? ["MaterialsTable", "AdjustmentsTable"]
+    : ["TimeTable", "MaterialsTable", "AdjustmentsTable"];
   const sectionData = {};
 
   debugLog(`collectAdvancedGridData starting for section: ${section}`);
@@ -202,6 +204,11 @@ function collectAdvancedGridData(section) {
     }
   });
 
+  // To ensure that reality section always has an empty time entries array to avoid autosaving
+  if (section === "reality") {
+    sectionData["time_entries"] = [];
+  }
+ 
   debugLog(`collectAdvancedGridData completed for ${section}:`, sectionData);
   return sectionData;
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of job pricing and time entries in the workflow application. The most important changes include adding validation, modifying the update logic in serializers, and enhancing logging for better debugging.

### Changes to validation and update logic:

* [`workflow/models/time_entry.py`](diffhunk://#diff-64f756323fbd5648feca5a0b5e0c8da2fd7bf3de4c18568ec76d023e5df63985R6): Added `ValidationError` import to enhance validation capabilities.
* [`workflow/serializers/job_pricing_serializer.py`](diffhunk://#diff-42584a312d4b4d1c2b728201b06983f7734c9d21bee00e880529d6758c49cfe1L131-R133): Modified the `update` method to prevent updating time entries when the pricing stage is `REALITY` and to remove time entries from `validated_data` in this stage. [[1]](diffhunk://#diff-42584a312d4b4d1c2b728201b06983f7734c9d21bee00e880529d6758c49cfe1L131-R133) [[2]](diffhunk://#diff-42584a312d4b4d1c2b728201b06983f7734c9d21bee00e880529d6758c49cfe1R149-R153)
* [`workflow/serializers/job_pricing_serializer.py`](diffhunk://#diff-42584a312d4b4d1c2b728201b06983f7734c9d21bee00e880529d6758c49cfe1L191-R197): Updated the `update` method to handle related fields separately and ensure other fields are updated correctly.

### Changes to JavaScript functions:

* [`workflow/static/js/job/edit_job_form_autosave.js`](diffhunk://#diff-e85d2725b4ef72d6d82e485e2a358b233bdacb1bb8186ee6c6799aff1db8a130L161-R163): Modified `collectAdvancedGridData` function to exclude `TimeTable` when the section is `reality` and ensure the reality section always has an empty time entries array. [[1]](diffhunk://#diff-e85d2725b4ef72d6d82e485e2a358b233bdacb1bb8186ee6c6799aff1db8a130L161-R163) [[2]](diffhunk://#diff-e85d2725b4ef72d6d82e485e2a358b233bdacb1bb8186ee6c6799aff1db8a130R207-R211)

### Enhancements to logging:

* [`workflow/views/time_entry_view.py`](diffhunk://#diff-ed643b7f14f7ea1a9c14408d28ff6b98d29c04e72edf201d49a92327323610c0R324): Added logging to capture request data and warn if a time entry has no staff assigned, including attempts to restore staff assignment. [[1]](diffhunk://#diff-ed643b7f14f7ea1a9c14408d28ff6b98d29c04e72edf201d49a92327323610c0R324) [[2]](diffhunk://#diff-ed643b7f14f7ea1a9c14408d28ff6b98d29c04e72edf201d49a92327323610c0R416-R428)
[Copilot is generating a summary...]