### PR TITLE
Feat: integrate automatic calculation of retail price for materials and adjustments in simple grids

### DIFF
--- a/workflow/static/js/job/deserialize_job_pricing.js
+++ b/workflow/static/js/job/deserialize_job_pricing.js
@@ -268,12 +268,14 @@ export function createNewRow(gridType) {
         description: "",
         material_cost: 0,
         retail_price: 0,
+        isManualOverride: false,
       };
     case "SimpleAdjustmentsTable":
       return {
         description: "",
         cost_adjustment: 0,
         price_adjustment: 0,
+        isManualOverride: false,
       };
     case "SimpleTotalTable":
       return {

--- a/workflow/static/js/job/grid/grid_options.js
+++ b/workflow/static/js/job/grid/grid_options.js
@@ -193,6 +193,65 @@ export function createCommonGridOptions() {
           });
           calculateSimpleTotals();
           break;
+
+        case "SimpleMaterialsTable":
+          if (event.column.colId === "material_cost" && !data.isManualOverride) {
+            fetchMaterialsMarkup(data).then((markupRate) => {
+              const cost = parseFloat(data.material_cost) || 0;
+              data.retail_price = calculateRetailRate(cost, markupRate);
+              event.api.refreshCells({
+                rowNodes: [event.node],
+                columns: ["retail_price"],
+                force: true,
+              });
+              calculateSimpleTotals();
+            });
+          }
+
+          if (event.column.colId === "retail_price") {
+            const cost = parseFloat(data.material_cost) || 0;
+            const retail = parseFloat(data.retail_price) || 0;
+
+            fetchMaterialsMarkup(data).then((markupRate) => {
+              const calculatedRetail = calculateRetailRate(cost, markupRate);
+              if (retail !== calculatedRetail) {
+                data.isManualOverride = true;
+              } else {
+                data.isManualOverride = false;
+              }
+              calculateSimpleTotals();
+            });
+          }
+          break;
+
+        case "SimpleAdjustmentsTable":
+          if (event.column.colId === "cost_adjustment" && !data.isManualOverride) {
+            fetchMaterialsMarkup(data).then((markupRate) => {
+              const cost = parseFloat(data.cost_adjustment) || 0;
+              data.price_adjustment = calculateRetailRate(cost, markupRate);
+              event.api.refreshCells({
+                rowNodes: [event.node],
+                columns: ["price_adjustment"],
+                force: true,
+              });
+              calculateSimpleTotals();
+            });
+          }
+
+          if (event.column.colId === "price_adjustment") {
+            const cost = parseFloat(data.cost_adjustment) || 0;
+            const retail = parseFloat(data.price_adjustment) || 0;
+
+            fetchMaterialsMarkup(data).then((markupRate) => {
+              const calculatedRetail = calculateRetailRate(cost, markupRate);
+              if (retail !== calculatedRetail) {
+                data.isManualOverride = true;
+              } else {
+                data.isManualOverride = false;
+              }
+              calculateSimpleTotals();
+            });
+          }
       }
 
       event.api.refreshCells({


### PR DESCRIPTION
This pull request introduces changes to the job pricing workflow in the JavaScript files, adding a new feature to handle manual overrides for material costs and price adjustments. The most important changes include the addition of the `isManualOverride` property and the logic to manage this property when material costs or price adjustments are modified.

Enhancements to job pricing workflow:

* [`workflow/static/js/job/deserialize_job_pricing.js`](diffhunk://#diff-19a13567062e4cc378439521c71d16bf458a12497c4aa30be5d3f93e1fc994c8R271-R278): Added the `isManualOverride` property to the return objects for `SimpleMaterialsTable` and `SimpleAdjustmentsTable` to track manual overrides.

* [`workflow/static/js/job/grid/grid_options.js`](diffhunk://#diff-f60040b787d51f26a192b748ebfbb5215a6fde0cfa1d92493678057465196684R196-R254): Implemented logic to update the `isManualOverride` property based on user interactions with the `material_cost` and `retail_price` columns in `SimpleMaterialsTable`, and the `cost_adjustment` and `price_adjustment` columns in `SimpleAdjustmentsTable`. This ensures that manual changes are accurately reflected and recalculates totals accordingly.