### PR TITLE
feat: add initial data fixture for workflow app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,6 @@ dmypy.json
 *.swp
 *.swo
 *~
-/workflow/fixtures/
 /.__debug_sql.lock
 /node_modules/
 

--- a/workflow/fixtures/initial_data.json
+++ b/workflow/fixtures/initial_data.json
@@ -1,0 +1,288 @@
+[
+    {
+      "model": "workflow.companydefaults",
+      "pk": "Demo Company (NZ)",
+      "fields": {
+        "time_markup": "0.30",
+        "materials_markup": "0.20",
+        "charge_out_rate": "105.00",
+        "wage_rate": "32.00",
+        "xero_tenant_id": "31d41e67-acad-400e-b2a9-aa6bb5e557a3",
+        "mon_start": "07:00:00",
+        "mon_end": "15:00:00",
+        "tue_start": "07:00:00",
+        "tue_end": "15:00:00",
+        "wed_start": "07:00:00",
+        "wed_end": "15:00:00",
+        "thu_start": "07:00:00",
+        "thu_end": "15:00:00",
+        "fri_start": "07:00:00",
+        "fri_end": "15:00:00",
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z"
+      }
+    },
+    {
+      "model": "workflow.client",
+      "pk": "00000000-0000-0000-0000-000000000001",
+      "fields": {
+        "xero_contact_id": null,
+        "name": "Demo Shop",
+        "email": "demo@example.com",
+        "phone": null,
+        "address": null,
+        "is_account_customer": false,
+        "raw_json": {},
+        "xero_last_modified": "2024-01-01T00:00:00Z",
+        "django_created_at": "2024-01-01T00:00:00Z",
+        "django_updated_at": "2024-01-01T00:00:00Z"
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000001",
+      "fields": {
+        "email": "charles.baker@example.com",
+        "first_name": "Charles",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe38",
+        "last_name": "Baker",
+        "preferred_name": "Charlie",
+        "wage_rate": "35.80",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000002",
+      "fields": {
+        "email": "alex.cooper@example.com",
+        "first_name": "Alex",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe39",
+        "last_name": "Cooper",
+        "preferred_name": null,
+        "wage_rate": "33.50",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000003",
+      "fields": {
+        "email": "nathan.chen@example.com",
+        "first_name": "Nathan",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe40",
+        "last_name": "Chen",
+        "preferred_name": "Nate",
+        "wage_rate": "36.25",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000004",
+      "fields": {
+        "email": "robert.irwin@example.com",
+        "first_name": "Robert",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe41",
+        "last_name": "Irwin",
+        "preferred_name": "Rob",
+        "wage_rate": "37.50",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000005",
+      "fields": {
+        "email": "peter.johnson@example.com",
+        "first_name": "Peter",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe42",
+        "last_name": "Johnson",
+        "preferred_name": "Pete",
+        "wage_rate": "34.75",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000006",
+      "fields": {
+        "email": "james.kennedy@example.com",
+        "first_name": "James",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe43",
+        "last_name": "Kennedy",
+        "preferred_name": "Jim",
+        "wage_rate": "36.00",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000007",
+      "fields": {
+        "email": "andrew.mitchell@example.com",
+        "first_name": "Andrew",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe44",
+        "last_name": "Mitchell",
+        "preferred_name": "Andy",
+        "wage_rate": "35.25",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000008",
+      "fields": {
+        "email": "anthony.parker@example.com",
+        "first_name": "Anthony",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe45",
+        "last_name": "Parker",
+        "preferred_name": "Tony",
+        "wage_rate": "33.75",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000009",
+      "fields": {
+        "email": "thomas.richards@example.com",
+        "first_name": "Thomas",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe46",
+        "last_name": "Richards",
+        "preferred_name": "Tom",
+        "wage_rate": "34.50",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000010",
+      "fields": {
+        "email": "matthew.robinson@example.com",
+        "first_name": "Matthew",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe47",
+        "last_name": "Robinson",
+        "preferred_name": "Matt",
+        "wage_rate": "36.50",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+      "model": "workflow.staff",
+      "pk": "10000000-0000-0000-0000-000000000011",
+      "fields": {
+        "email": "patrick.xu@example.com",
+        "first_name": "Patrick",
+        "ims_payroll_id": "4ac80a91-1aee-434b-88a9-c509b48bfe48",
+        "last_name": "Xu",
+        "preferred_name": null,
+        "wage_rate": "35.00",
+        "hours_mon": "8.0",
+        "hours_tue": "8.0",
+        "hours_wed": "8.0",
+        "hours_thu": "8.0",
+        "hours_fri": "8.0",
+        "hours_sat": "0.00",
+        "hours_sun": "0.00",
+        "raw_ims_data": {}
+      }
+    },
+    {
+        "model": "workflow.staff",
+        "pk": "10000000-0000-0000-0000-000000000012",
+        "fields": {
+          "password": "pbkdf2_sha256$870000$5Nw3RUuFaZZPCkeyVOm4kx$Attep1SqGF6ymdwm44LOte4wwszqte0W5ey3xcENFAI=",
+          "email": "defaultadmin@example.com",
+          "first_name": "Default",
+          "last_name": "Admin",
+          "preferred_name": null,
+          "wage_rate": "40.00",
+          "hours_mon": "8.0",
+          "hours_tue": "8.0",
+          "hours_wed": "8.0",
+          "hours_thu": "8.0",
+          "hours_fri": "8.0",
+          "hours_sat": "0.00",
+          "hours_sun": "0.00",
+          "ims_payroll_id": "ADMIN-001",
+          "is_active": true,
+          "is_staff": true,
+          "is_superuser": true,
+          "date_joined": "2024-01-01T00:00:00Z",
+          "raw_ims_data": {},
+          "created_at": "2024-01-01T00:00:00Z",
+          "updated_at": "2024-01-01T00:00:00Z"
+        }
+      }
+  ]


### PR DESCRIPTION

This pull request adds initial data fixtures for the `workflow` module. The changes include adding default data for company settings, clients, and staff members.

### Initial Data Fixtures:

* Added default company settings for "Demo Company (NZ)" including time and materials markup, charge out rate, wage rate, and working hours. (`workflow/fixtures/initial_data.json`)
* Added a default client "Demo Shop" with basic contact information. (`workflow/fixtures/initial_data.json`)
* Added multiple staff members with details such as email, first name, last name, wage rate, weekly working hours, and raw IMS data. (`workflow/fixtures/initial_data.json`)
* Added a default admin user with staff and superuser privileges, including hashed password and account creation details. (`workflow/fixtures/initial_data.json`)
