### PR TITLE
feat(sync.py): add logging for accounts sync to track progress

### DIFF
--- a/workflow/api/xero/sync.py
+++ b/workflow/api/xero/sync.py
@@ -131,6 +131,16 @@ def sync_xero_data(
                         "progress": 0.0,
                         "totalItems": total_items
                     }
+                case "accounts":
+                    total_items = len(items)  # For accounts, we get all items at once
+                    yield {
+                        "datetime": timezone.now().isoformat(),
+                        "entity": our_entity_type,
+                        "severity": "info",
+                        "message": f"Found {total_items} accounts to sync",
+                        "progress": 0.0,
+                        "totalItems": total_items
+                    }
                 case "journals":
                     total_items = len(items)  # For journals, we get all items at once
                     yield {


### PR DESCRIPTION
This pull request includes a change to the `sync_xero_data` function in the `workflow/api/xero/sync.py` file to handle the synchronization of accounts data. The most important change is the addition of a new case for handling accounts, which includes logging the total number of accounts to be synced.

Enhancements to data synchronization:

* [`workflow/api/xero/sync.py`](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6R134-R143): Added a new case for "accounts" in the `sync_xero_data` function to log the total number of accounts found for synchronization.
[Copilot is generating a summary...]