### PR TITLE
Remove "refresh_xero_data" cache flag to avoid multiple xero syncs

### DIFF
--- a/workflow/api/xero/sync.py
+++ b/workflow/api/xero/sync.py
@@ -1165,9 +1165,9 @@ def deep_sync_xero_data(days_back=30):
     }
     yield from _sync_all_xero_data(use_latest_timestamps=False, days_back=days_back)
 
-def synchronise_xero_data(delay_between_requests=1, refresh_xero_data=False):
+def synchronise_xero_data(delay_between_requests=1):
     """Bidirectional sync with Xero - pushes changes TO Xero, then pulls FROM Xero"""
-    if not cache.add('xero_sync_lock', True, timeout=(60 * 60 * 4)) and not refresh_xero_data:  # 4 hours
+    if not cache.add('xero_sync_lock', True, timeout=(60 * 60 * 4)):  # 4 hours
         logger.info("Skipping sync - another sync is running")
         yield {
             "datetime": timezone.now().isoformat(),
@@ -1247,7 +1247,6 @@ def synchronise_xero_data(delay_between_requests=1, refresh_xero_data=False):
         raise
     finally:
         cache.delete('xero_sync_lock')
-        cache.delete('refresh_xero_data')
 
 
 def delete_client_from_xero(client):

--- a/workflow/api/xero/sync.py
+++ b/workflow/api/xero/sync.py
@@ -1177,8 +1177,6 @@ def synchronise_xero_data(delay_between_requests=1):
             "progress": None
         }
         return
-    
-    cache.add('refresh_xero_data', True, timeout=(60 * 15)) # 15 minutes in cache
 
     logger.info("Starting bi-directional Xero sync")
     yield {

--- a/workflow/views/xero_view.py
+++ b/workflow/views/xero_view.py
@@ -138,7 +138,7 @@ def generate_xero_sync_events():
         last_heartbeat = timezone.now()
         
         # Proceed with sync if we have a valid token
-        messages = synchronise_xero_data(refresh_xero_data=True)
+        messages = synchronise_xero_data()
         for message in messages:
             # Check if we need to send a heartbeat
             now = timezone.now()


### PR DESCRIPTION
This pull request focuses on simplifying the Xero data synchronization process by removing the `refresh_xero_data` parameter and associated cache operations from the `synchronise_xero_data` function. Here are the most important changes:

Simplification of Xero synchronization:

* [`workflow/api/xero/sync.py`](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L1168-R1170): Removed the `refresh_xero_data` parameter from the `synchronise_xero_data` function and eliminated the associated cache operations. [[1]](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L1168-R1170) [[2]](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L1181-L1182) [[3]](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L1250)
* [`workflow/views/xero_view.py`](diffhunk://#diff-18890cd6ed281cab7d155721067263b328754f124aa2277c3ebc4689df0abc52L141-R141): Updated the call to `synchronise_xero_data` to no longer pass the `refresh_xero_data` parameter.