### PR TITLE
Xero sync bug

### DIFF
--- a/workflow/api/xero/reprocess_xero.py
+++ b/workflow/api/xero/reprocess_xero.py
@@ -154,6 +154,9 @@ def set_client_fields(client, new_from_xero=False):
 
     raw_data = client.raw_json
 
+    if "_contacts" in raw_data and raw_data["_contacts"]:
+        raw_data = raw_data["_contacts"][0]
+
     # Extract basic client fields from raw JSON
     client.name = raw_data.get("_name")
     client.email = raw_data.get("_email_address")

--- a/workflow/api/xero/sync.py
+++ b/workflow/api/xero/sync.py
@@ -371,7 +371,7 @@ def sync_invoices(invoices):
         # Retrieve the client for the invoice first
         try:
             client = get_or_fetch_client_by_contact_id(
-                inv.contact.contact_id,
+                inv.contact.contact_id,     
                 inv.invoice_number
             )
         except ValueError as e:


### PR DESCRIPTION
This pull request includes a change to the `workflow/api/xero/reprocess_xero.py` file to handle the extraction of client fields more accurately.

* [`workflow/api/xero/reprocess_xero.py`](diffhunk://#diff-e7257933b69bfcd8458873daa9b067153ca9dc96d3b39410c1993d74f9f8ec13R157-R159): Added a check to see if the `raw_data` contains `_contacts` and if it is not empty, then set `raw_data` to the first contact in the `_contacts` list. This ensures that client fields are extracted correctly when `_contacts` is present.