### PR TITLE
Xero sync bug

### DIFF
--- a/workflow/api/xero/reprocess_xero.py
+++ b/workflow/api/xero/reprocess_xero.py
@@ -166,7 +166,7 @@ def set_client_fields(client, new_from_xero=False):
 
     # Handling the address
     addresses = raw_data.get("addresses", [])
-    client.address = addresses[0].get("address_line1", "") if addresses else ""3
+    client.address = addresses[0].get("address_line1", "") if addresses else ""
 
     # Handling payment terms (keeping the condition from old logic)
     payment_terms = raw_data.get("payment_terms")

--- a/workflow/api/xero/reprocess_xero.py
+++ b/workflow/api/xero/reprocess_xero.py
@@ -166,7 +166,7 @@ def set_client_fields(client, new_from_xero=False):
 
     # Handling the address
     addresses = raw_data.get("addresses", [])
-    client.address = addresses[0].get("address_line1", "") if addresses else ""
+    client.address = addresses[0].get("address_line1", "") if addresses else ""3
 
     # Handling payment terms (keeping the condition from old logic)
     payment_terms = raw_data.get("payment_terms")

--- a/workflow/api/xero/sync.py
+++ b/workflow/api/xero/sync.py
@@ -361,12 +361,14 @@ def get_or_fetch_client_by_contact_id(contact_id, invoice_number=None):
         logger.warning(f"Client not found for {entity_ref}")
         raise ValueError(f"Client not found for {entity_ref}")
 
-    synced_clients = sync_clients([missing_client])
+    synced_clients = sync_clients([missing_client], sync_back_to_xero=False)
     if not synced_clients:
         entity_ref = f"invoice {invoice_number}" if invoice_number else f"contact ID {contact_id}"
         logger.warning(f"Client not found for {entity_ref}")
         raise ValueError(f"Client not found for {entity_ref}")
     return synced_clients[0]
+
+
 def sync_invoices(invoices):
     """Sync Xero invoices (ACCREC)."""
     for inv in invoices:
@@ -563,7 +565,7 @@ def sync_journals(journals):
             raise
 
 
-def sync_clients(xero_contacts):
+def sync_clients(xero_contacts, sync_back_to_xero=True):
     """
     Sync clients fetched from Xero API.
     Returns a list of Client instances that were created or updated.
@@ -599,7 +601,8 @@ def sync_clients(xero_contacts):
                     f"updated_at={client.xero_last_modified}"
                 )
 
-            sync_client_to_xero(client)
+            if sync_back_to_xero:
+                sync_client_to_xero(client)
             client_instances.append(client)
 
         except Exception as e:


### PR DESCRIPTION
This pull request includes changes to the `workflow/api/xero/sync.py` file to enhance the client synchronization process by adding an option to control whether clients should be synced back to Xero. The most important changes include modifying the `sync_clients` function to accept a new parameter and updating the `get_or_fetch_client_by_contact_id` function to use this new parameter.

Enhancements to client synchronization:

* [`workflow/api/xero/sync.py`](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L566-R568): Modified the `sync_clients` function to accept a new parameter `sync_back_to_xero` with a default value of `True`. This allows control over whether clients should be synced back to Xero.
* [`workflow/api/xero/sync.py`](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6L364-R371): Updated the `get_or_fetch_client_by_contact_id` function to call `sync_clients` with `sync_back_to_xero` set to `False`. This change prevents unnecessary synchronization of clients back to Xero when fetching clients by contact ID.
* [`workflow/api/xero/sync.py`](diffhunk://#diff-c8d8e7f09546245380e8530c0129373db63348d1e42f7c6a25e78b1b0085c5f6R604): Added a condition within the `sync_clients` function to check the `sync_back_to_xero` parameter before calling `sync_client_to_xero`. This ensures that clients are only synced back to Xero if the parameter is set to `True`.