### PR TITLE
fix(workflow): resolve staff name display and UUID handling

### DIFF
--- a/workflow/templates/jobs/job_event_section.html
+++ b/workflow/templates/jobs/job_event_section.html
@@ -37,7 +37,7 @@
                         <p class="mb-1">{{ event.description|linebreaksbr }}</p>
                         <small class="text-muted">By 
                             {% if event.staff %}
-                                {{ event.staff }}
+                                {{ event.staff.get_display_full_name }}
                             {% else %}
                                 System
                             {% endif %}

--- a/workflow/utils.py
+++ b/workflow/utils.py
@@ -122,9 +122,13 @@ def get_excluded_staff():
             # Get the Staff model dynamically only when needed
             # This is so the installation process can run without the database being ready
             from workflow.models import Staff
-            dynamic_excluded_ids = [
-                str(staff.id) for staff in Staff.objects.filter(ims_payroll_id__isnull=True)
-            ]
+            dynamic_excluded_ids = []
+            for staff in Staff.objects.all():
+                try:
+                    uuid.UUID(staff.ims_payroll_id)
+                except ValueError:
+                    # If the UUID conversion fails, add the staff ID to the excluded list
+                    dynamic_excluded_ids.append(staff.id)
             return static_excluded_ids + dynamic_excluded_ids
         except (ProgrammingError, OperationalError):
             # If the table doesn't exist yet (during migrations), return only static IDs

--- a/workflow/views/edit_job_view_ajax.py
+++ b/workflow/views/edit_job_view_ajax.py
@@ -54,7 +54,7 @@ def api_fetch_status_values(request):
 def create_job_api(request):
     try:
         # Create the job with default values using the service function
-        new_job = Job.objects.create()
+        new_job = Job()
         new_job.save(staff=request.user)
 
         # Log that the job and pricings have been created successfully
@@ -456,7 +456,7 @@ def add_job_event(request, job_id):
                     "event_type": "manual_note",
                     "description": event.description,
                     "staff": (
-                        request.user.get_display_name() if request.user else "System"
+                        request.user.get_display_full_name() if request.user else "System"
                     ),
                 },
             },


### PR DESCRIPTION
This commit fixes two issues:

1.  Updates the display of staff names in job events to use `get_display_full_name` for consistency.

2.  Improves UUID validation for `ims_payroll_id` to prevent errors when non-UUID values are present. It now attempts to convert the value to a UUID and excludes the staff ID if the conversion fails.

feat(workflow): create job object before saving

This commit modifies the job creation process to instantiate a `Job` object before saving it. This ensures that the object exists in memory before any operations are performed on it, preventing potential errors.