### PR TITLE
feat(add_client.html): display error messages in a styled alert box

### DIFF
--- a/workflow/templates/clients/add_client.html
+++ b/workflow/templates/clients/add_client.html
@@ -39,6 +39,19 @@
 <div class="form-container card-enhanced fadeInUp">
     <h2 class="page-title">Add New Client</h2>
 
+    <div id="error-container" class="alert alert-danger" style="display: none;" role="alert">
+        <h4 class="alert-heading">Error</h4>
+        <p id="error-message"></p>
+        <div id="error-details" style="display: none;">
+            <hr>
+            <div class="small">
+                <strong id="error-type">Error Type: Unknown</strong><br>
+                Failed Operation: Adding client "<span id="error-name"></span>"
+                <span id="error-email-container">(<span id="error-email"></span>)</span>
+            </div>
+        </div>
+    </div>
+
     {% if error %}
     <div class="alert alert-danger" role="alert">
         <h4 class="alert-heading">Error</h4>


### PR DESCRIPTION
This commit introduces a new styled alert box to display error messages when adding a new client. The alert box includes a heading, a general error message, and optional details such as the error type, the name of the client that failed to be added, and the client's email address. The alert box is initially hidden and is displayed when an error occurs. This provides a more user-friendly way to display error messages to the user.