### PR TITLE
fix(kpi_service.py): change filtering of material and adjustment entr…

### DIFF
--- a/workflow/services/kpi_service.py
+++ b/workflow/services/kpi_service.py
@@ -158,14 +158,14 @@ class KPIService:
         }
 
         material_entries = MaterialEntry.objects.filter(
-            job_pricing__time_entries__date__range=[start_date, end_date]
+            created_at__range=[start_date, end_date]
         ).values("job_pricing__time_entries__date").annotate(
             revenue=Sum(F("unit_revenue") * F("quantity"), output_field=decimal_field),
             cost=Sum(F("unit_cost") * F("quantity"), output_field=decimal_field)
         )
 
         adjustment_entries = AdjustmentEntry.objects.filter(
-            job_pricing__time_entries__date__range=[start_date, end_date]
+            created_at__range=[start_date, end_date]
         ).values("job_pricing__time_entries__date").annotate(
             revenue_adj=Sum(F("price_adjustment")),
             cost_adj=Sum(F("cost_adjustment"))


### PR DESCRIPTION
…ies to use created_at field instead of job_pricing__time_entries__date field

The change is needed because the original filtering logic was incorrect and did not return the correct data.