### PR TITLE
Add/edit client button inside client dropdown

### DIFF
--- a/job/management/commands/create_shop_jobs.py
+++ b/job/management/commands/create_shop_jobs.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
 
-from workflow.models import Client, Job, CompanyDefaults
+from workflow.models import Client, CompanyDefaults
+
+from job.models import Job
 
 
 class Command(BaseCommand):

--- a/job/static/job/js/edit_job_form_autosave.js
+++ b/job/static/job/js/edit_job_form_autosave.js
@@ -1560,15 +1560,17 @@ document.addEventListener("DOMContentLoaded", function () {
           const manageOption = new Option("--- Add/Edit Contact Persons in Xero ---", "__XERO_MANAGE_CONTACTS__");
           manageOption.classList.add('xero-manage-option');
           
+          contactSelect.appendChild(manageOption);
           contactSelect.dataset.xeroContactId = clientXeroIdField.value;
         }
 
-        contactSelect.dispatchEvent(new Event('change'));
+        contactSelect.dispatchEvent(new Event('change')); 
       })
       .catch(error => {
         console.error('populateContactPersonDropdown: Error fetching contact persons:', error);
         // Use populateSelectWithOptions for consistent error display
         populateSelectWithOptions(contactSelect, [], () => ({}), 'Error loading contacts', null);
+        contactSelect.dispatchEvent(new Event('change'));
       });
   }
 

--- a/job/static/job/js/edit_job_form_autosave.js
+++ b/job/static/job/js/edit_job_form_autosave.js
@@ -1557,9 +1557,13 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const clientXeroIdField = document.getElementById('client_xero_id');
         if (clientXeroIdField && clientXeroIdField.value) {
-          manageXeroContactsButton.style.display = 'inline-block';
-          manageXeroContactsButton.dataset.xeroContactId = clientXeroIdField.value;
+          const manageOption = new Option("--- Add/Edit Contact Persons in Xero ---", "__XERO_MANAGE_CONTACTS__");
+          manageOption.classList.add('xero-manage-option');
+          
+          contactSelect.dataset.xeroContactId = clientXeroIdField.value;
         }
+
+        contactSelect.dispatchEvent(new Event('change'));
       })
       .catch(error => {
         console.error('populateContactPersonDropdown: Error fetching contact persons:', error);
@@ -1703,6 +1707,23 @@ document.addEventListener("DOMContentLoaded", function () {
   if (contactSelect) {
       contactSelect.addEventListener('change', function () {
           const selectedOption = this.options[this.selectedIndex];
+
+          if (selectedOption && selectedOption.value === "__XERO_MANAGE_CONTACTS__") {
+            const xeroContactId = this.dataset.xeroContactId;
+            if (xeroContactId) {
+                window.open(`https://go.xero.com/Contacts/View.aspx?contactID=${xeroContactId}`, '_blank');
+            } else {
+                alert('Client Xero ID not found. Please select a client synced with Xero.');
+            }
+
+            this.value = ''; // Reset the select
+            if (contactNameHidden) contactNameHidden.value = '';
+            if (contactEmailHidden) contactEmailHidden.value = '';
+
+            debouncedAutosave();
+            return;
+          }
+
           if (selectedOption && selectedOption.value) {
               contactNameHidden.value = selectedOption.dataset.contactName || selectedOption.text.split(' (')[0]; // Fallback if data-contact-name is not set
               contactEmailHidden.value = selectedOption.value;

--- a/job/templates/jobs/edit_job_detail_section.html
+++ b/job/templates/jobs/edit_job_detail_section.html
@@ -45,7 +45,7 @@
             <input type="hidden" id="contact_person_name_hidden" name="contact_person" class="autosave-input" value="{{ job.contact_person|default_if_none:'' }}">
             <input type="hidden" id="contact_person_email_hidden" name="contact_email" class="autosave-input" value="{{ job.contact_email|default_if_none:'' }}">
             
-            <div class="mt-2">
+            <div class="d-none">
                 <button type="button" id="manage_xero_contact_persons_button" class="btn btn-sm btn-outline-secondary" style="display:none;">
                     Add/Edit Contact Persons in Xero
                 </button>


### PR DESCRIPTION
This pull request includes updates to improve the integration with Xero for managing contact persons, refactors imports in a Django management command, and makes minor UI adjustments. Below is a summary of the most important changes:

### Xero Integration Enhancements:
* Updated `edit_job_form_autosave.js` to add a new option in the contact dropdown for managing Xero contacts. Selecting this option opens the Xero contact management page in a new tab and resets the dropdown after the action. (`[[1]](diffhunk://#diff-e767e8cc07dab3dad849b402728b2cfbaff11ad3254dc171d3c7907df6a6dea7L1560-R1573)`, `[[2]](diffhunk://#diff-e767e8cc07dab3dad849b402728b2cfbaff11ad3254dc171d3c7907df6a6dea7R1712-R1728)`)
* Dispatched a `change` event programmatically after updates to the contact dropdown to ensure UI consistency. (`[[1]](diffhunk://#diff-e767e8cc07dab3dad849b402728b2cfbaff11ad3254dc171d3c7907df6a6dea7L1560-R1573)`, `[[2]](diffhunk://#diff-e767e8cc07dab3dad849b402728b2cfbaff11ad3254dc171d3c7907df6a6dea7R1712-R1728)`)

### Refactoring:
* Refactored imports in `create_shop_jobs.py` by moving the `Job` model import to the `job.models` module for better organization. (`[job/management/commands/create_shop_jobs.pyL3-R5](diffhunk://#diff-7f4dfabe7c8e1c13383364dddafe7e71a1d4a3109d3d2dc77a228db2e6783bfbL3-R5)`)

### UI Adjustments:
* Hid the "Add/Edit Contact Persons in Xero" button in the job details section by applying the `d-none` class, as it is now replaced by the dropdown option. (`[job/templates/jobs/edit_job_detail_section.htmlL48-R48](diffhunk://#diff-cbdcda65a61f4e5cad7abf72efbb0646e2634f5b92ddff9e29ee5aee99a9208fL48-R48)`)