### PR TITLE
Fix typos in linked quote plan

### DIFF
--- a/docs/plans/linked_quote_implementation_plan.md
+++ b/docs/plans/linked_quote_implementation_plan.md
@@ -32,12 +32,12 @@ After examining the codebase, we've identified the following key components:
 
 ### Ticket 0: Data model fixes
 
-Add parts to job pricing, and remove the time/material/adjustmeent entries
-Ensure job pricing has a defualt part
+Add parts to job pricing, and remove the time/material/adjustment entries
+Ensure job pricing has a default part
 Move all existing data to that default part
 TEST EVERYTHING
 
-After this change, everything MUST go thorugh the parts.  I.e. you cannot get the time entries for a job pricing.
+After this change, everything MUST go through the parts.  I.e. you cannot get the time entries for a job pricing.
 This requires fixing the APIs, the serialisers, the JS, etc.
 
 No UI changes.   


### PR DESCRIPTION
## Summary
- fix typos in the linked quote plan doc

## Testing
- `tox -q` *(fails: Package 'jobs-manager' requires a different Python: 3.11.12 not in '<4.0,>=3.12')*

------
https://chatgpt.com/codex/tasks/task_e_6843ba3f53f4832284c1015426e5041e