### PR TITLE
Add Excel quote import endpoint

### DIFF
--- a/apps/job/services/import_quote_service.py
+++ b/apps/job/services/import_quote_service.py
@@ -1,0 +1,147 @@
+from decimal import Decimal
+from typing import Optional
+
+import pandas as pd
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from apps.job.enums import JobPricingStage
+from apps.job.models import AdjustmentEntry, Job, JobPart, JobPricing, MaterialEntry
+
+MANDATORY_COLUMNS = [
+    "Description",
+    "quantity",
+    "thickness",
+    "Materials",
+    "Labor / laser (internal)",
+    "bend cost",
+    "bend setup fee",
+    "hole cost",
+    "weld cost",
+    "Material cost",
+    "Pipe (RHS/SHS/pipe)",
+    "Preparation (detail/finish)",
+    "CLEAR",
+]
+
+ADJUSTMENT_COLUMNS = [
+    "bend cost",
+    "bend setup fee",
+    "hole cost",
+    "weld cost",
+    "Pipe (RHS/SHS/pipe)",
+    "Preparation (detail/finish)",
+]
+
+
+@transaction.atomic
+def import_quote_from_excel(
+    *, job: Job, file, job_pricing_id: Optional[str] = None
+) -> dict:
+    """Create JobParts from a spreadsheet and return summary."""
+
+    xl = pd.ExcelFile(file, engine="openpyxl")
+
+    try:
+        df = xl.parse("Primary Details")
+    except ValueError as exc:
+        raise ValidationError("Missing 'Primary Details' sheet") from exc
+
+    missing_cols = [c for c in MANDATORY_COLUMNS if c not in df.columns]
+    if missing_cols:
+        raise ValidationError(f"Missing mandatory columns: {', '.join(missing_cols)}")
+
+    # Validate materials sheet
+    try:
+        materials_df = xl.parse("Materials")
+    except ValueError:
+        raise ValidationError("Missing 'Materials' sheet")
+
+    for col in ["thickness", "Materials"]:
+        if col not in materials_df.columns:
+            raise ValidationError(f"Materials sheet missing '{col}' column")
+
+    valid_thickness = set(str(x) for x in materials_df["thickness"].dropna())
+    valid_materials = set(str(x) for x in materials_df["Materials"].dropna())
+
+    # Determine job pricing
+    job_pricing: Optional[JobPricing] = None
+    if job_pricing_id:
+        try:
+            job_pricing = JobPricing.objects.get(id=job_pricing_id, job=job)
+        except JobPricing.DoesNotExist as exc:
+            raise ValidationError("Invalid job_pricing_id") from exc
+    else:
+        job_pricing = job.pricings.filter(
+            pricing_stage=JobPricingStage.ESTIMATE
+        ).first()
+        if job_pricing is None:
+            job_pricing = JobPricing.objects.create(
+                job=job, pricing_stage=JobPricingStage.ESTIMATE
+            )
+            job.latest_estimate_pricing = job_pricing
+            job.save(update_fields=["latest_estimate_pricing"])
+
+    parts_created = 0
+    total_material_cost = Decimal("0")
+    total_adjustments_cost = Decimal("0")
+
+    for _, row in df.iterrows():
+        description = str(row.get("Description", "")).strip()
+        clear_val = str(row.get("CLEAR", "")).strip().upper()
+        if not description or clear_val == "CLEAR":
+            continue
+
+        quantity = Decimal(str(row.get("quantity", 0)))
+        if quantity <= 0:
+            raise ValidationError("Quantity must be greater than zero")
+
+        thickness_val = str(row.get("thickness", ""))
+        material_val = str(row.get("Materials", ""))
+        if thickness_val not in valid_thickness or material_val not in valid_materials:
+            raise ValidationError("Invalid thickness or material")
+
+        part = JobPart.objects.create(
+            job_pricing=job_pricing,
+            name=description,
+            description=description,
+        )
+
+        material_cost = Decimal(str(row.get("Material cost", 0)))
+        unit_cost = material_cost / quantity if quantity else Decimal("0")
+
+        MaterialEntry.objects.create(
+            job_pricing=job_pricing,
+            description=material_val,
+            comments=f"{thickness_val}mm {material_val}",
+            quantity=quantity,
+            unit_cost=unit_cost,
+            unit_revenue=unit_cost,
+        )
+
+        adjustments_total = Decimal("0")
+        for col in ADJUSTMENT_COLUMNS:
+            value = Decimal(str(row.get(col, 0)))
+            if value != 0:
+                AdjustmentEntry.objects.create(
+                    job_pricing=job_pricing,
+                    description=col,
+                    cost_adjustment=value,
+                    price_adjustment=Decimal("0"),
+                )
+                adjustments_total += value
+
+        labor_cost = Decimal(str(row.get("Labor / laser (internal)", 0)))
+
+        part.raw_total_cost = material_cost + adjustments_total + labor_cost
+
+        parts_created += 1
+        total_material_cost += material_cost
+        total_adjustments_cost += adjustments_total
+
+    return {
+        "job_pricing_id": str(job_pricing.id),
+        "partes_criadas": parts_created,
+        "total_material_cost": str(total_material_cost),
+        "total_adjustments_cost": str(total_adjustments_cost),
+    }

--- a/apps/job/static/job/js/import_quote.js
+++ b/apps/job/static/job/js/import_quote.js
@@ -1,0 +1,43 @@
+import { getCSRFToken } from "./job_file_handling.js";
+
+function getJobIdFromUrl() {
+  const match = window.location.pathname.match(/job\/(.+?)\//);
+  return match ? match[1] : "";
+}
+
+function initImportQuote() {
+  const button = document.getElementById("importQuoteButton");
+  const fileInput = document.getElementById("importQuoteFile");
+  if (!button || !fileInput) return;
+
+  button.addEventListener("click", () => fileInput.click());
+
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    const jobId = getJobIdFromUrl();
+    const formData = new FormData();
+    formData.append("file", file);
+    try {
+      const resp = await fetch(`/api/jobs/${jobId}/import-quote/`, {
+        method: "POST",
+        headers: { "X-CSRFToken": getCSRFToken() },
+        body: formData,
+      });
+      const data = await resp.json();
+      if (!resp.ok) {
+        alert(data.error || "Import failed");
+      } else {
+        alert(`Imported ${data.partes_criadas} parts`);
+        window.location.reload();
+      }
+    } catch (err) {
+      console.error("Import failed", err);
+      alert("Import failed");
+    } finally {
+      fileInput.value = "";
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initImportQuote);

--- a/apps/job/static/job/js/index.js
+++ b/apps/job/static/job/js/index.js
@@ -6,6 +6,7 @@ import {
 } from "./grid/grid_initialization.js";
 import { toggleGrid } from "./job_buttons/button_utils.js";
 import { handleButtonClick } from "./job_buttons/button_handlers.js";
+import "./import_quote.js";
 
 // Initialize all modules when the document is ready
 document.addEventListener("DOMContentLoaded", function () {

--- a/apps/job/templates/jobs/edit_job_ajax.html
+++ b/apps/job/templates/jobs/edit_job_ajax.html
@@ -114,6 +114,10 @@
                 id="deleteQuoteButton">
                 <i class="bi bi-trash me-2"></i>Delete Xero Quote
             </button>
+            <input type="file" id="importQuoteFile" class="d-none">
+            <button id="importQuoteButton" class="btn btn-secondary">
+                <i class="bi bi-upload me-2"></i>Import Quote
+            </button>
         </div>
     </div>
 

--- a/apps/job/tests/conftest.py
+++ b/apps/job/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from django.conf import settings
+
+
+@pytest.fixture(autouse=True)
+def _use_sqlite_db(settings):
+    settings.DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _set_required_env_vars(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("DROPBOX_WORKFLOW_FOLDER", "tmp")
+    monkeypatch.setenv("XERO_CLIENT_ID", "x")
+    monkeypatch.setenv("XERO_CLIENT_SECRET", "x")
+    monkeypatch.setenv("XERO_REDIRECT_URI", "http://example.com")

--- a/apps/job/tests/test_import_quote_api.py
+++ b/apps/job/tests/test_import_quote_api.py
@@ -1,0 +1,88 @@
+import io
+
+import pandas as pd
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from apps.job.models import Job
+
+
+@pytest.fixture
+def staff(db):
+    User = get_user_model()
+    return User.objects.create_user(email="staff@example.com", password="testpass")
+
+
+@pytest.fixture
+def client_logged(client, staff):
+    client.force_login(staff)
+    return client
+
+
+def create_excel(quantity=1, include_description=True, extra_cols=None):
+    data = {
+        "quantity": [quantity],
+        "Description": ["Part A" if include_description else ""],
+        "Labor / laser (internal)": [90],
+        "thickness": [1.5],
+        "Materials": ["SS316"],
+        "bend cost": [9],
+        "bend setup fee": [10],
+        "hole cost": [15],
+        "weld cost": [48],
+        "Material cost": [276.5],
+        "Pipe (RHS/SHS/pipe)": [12.0],
+        "Preparation (detail/finish)": [30],
+        "CLEAR": [""],
+    }
+    if extra_cols:
+        data.update(extra_cols)
+    df_primary = pd.DataFrame(data)
+    materials_df = pd.DataFrame({"thickness": [1.5], "Materials": ["SS316"]})
+    buf = io.BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        df_primary.to_excel(writer, sheet_name="Primary Details", index=False)
+        materials_df.to_excel(writer, sheet_name="Materials", index=False)
+    buf.seek(0)
+    return buf
+
+
+@pytest.fixture
+def job(db, staff):
+    job = Job(name="Test", charge_out_rate=1)
+    job.save(staff=staff)
+    return job
+
+
+def test_upload_valid_spreadsheet(client_logged, job):
+    file = create_excel()
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client_logged.post(url, {"file": file})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["partes_criadas"] == 1
+
+
+def test_missing_columns(client_logged, job):
+    file = create_excel()
+    # remove a mandatory column
+    buf = io.BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        pd.DataFrame({"foo": [1]}).to_excel(
+            writer, sheet_name="Primary Details", index=False
+        )
+        pd.DataFrame({"thickness": [1.5], "Materials": ["SS316"]}).to_excel(
+            writer, sheet_name="Materials", index=False
+        )
+    buf.seek(0)
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client_logged.post(url, {"file": buf})
+    assert response.status_code == 400
+
+
+def test_quantity_zero_error(client_logged, job):
+    file = create_excel(quantity=0)
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client_logged.post(url, {"file": file})
+    assert response.status_code == 400

--- a/apps/job/urls.py
+++ b/apps/job/urls.py
@@ -12,13 +12,14 @@ This module contains all URL patterns related to job management:
 from django.urls import path
 
 from apps.job.views import (
-    edit_job_view_ajax,
-    kanban_view,
-    workshop_view,
-    job_management_view,
     ArchiveCompleteJobsViews,
     AssignJobView,
     JobFileView,
+    edit_job_view_ajax,
+    import_quote_view,
+    job_management_view,
+    kanban_view,
+    workshop_view,
 )
 
 app_name = "jobs"
@@ -78,6 +79,11 @@ urlpatterns = [
         "api/job-event/<uuid:job_id>/add-event/",
         edit_job_view_ajax.add_job_event,
         name="add-event",
+    ),
+    path(
+        "api/jobs/<uuid:job_id>/import-quote/",
+        import_quote_view.import_quote,
+        name="import_quote",
     ),
     path("api/job-files/", JobFileView.as_view(), name="job-files"),  # For POST/PUT
     path(

--- a/apps/job/views/import_quote_view.py
+++ b/apps/job/views/import_quote_view.py
@@ -1,0 +1,32 @@
+import logging
+
+from django.db import transaction
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.http import require_http_methods
+
+from apps.job.models import Job
+from apps.job.services.import_quote_service import import_quote_from_excel
+
+logger = logging.getLogger(__name__)
+
+
+@require_http_methods(["POST"])
+@transaction.atomic
+def import_quote(request, job_id):
+    job = get_object_or_404(Job, id=job_id)
+
+    file = request.FILES.get("file")
+    if not file:
+        return JsonResponse({"error": "No file uploaded"}, status=400)
+
+    job_pricing_id = request.POST.get("job_pricing_id")
+
+    try:
+        result = import_quote_from_excel(
+            job=job, file=file, job_pricing_id=job_pricing_id
+        )
+        return JsonResponse(result)
+    except Exception as exc:
+        logger.exception("Error importing quote")
+        return JsonResponse({"error": str(exc)}, status=400)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = jobs_manager.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Summary
- implement Excel quote import service and view
- expose POST `/api/jobs/<job_id>/import-quote/`
- add frontend button and JS logic to upload file
- include basic tests for the endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'crispy_forms')*

------
https://chatgpt.com/codex/tasks/task_e_6845d946607883319128d05502d90e96