### PR TITLE
Improve Steel & Tube scraper login failure handling

### DIFF
--- a/apps/quoting/scrapers/steel_and_tube.py
+++ b/apps/quoting/scrapers/steel_and_tube.py
@@ -125,11 +125,16 @@ class SteelAndTubeScraper(BaseScraper):
         if "login" in self.driver.current_url.lower() or "signin" in self.driver.current_url.lower():
             self.logger.info("Login required, attempting to login...")
             if not self.login():
-                self.logger.error("Login failed. Cannot proceed with scraping this product.")
+                self.logger.error("Login failed. Bailing out of product scraping.")
                 return []
             # Navigate back to product page after login
             self.driver.get(url)
             time.sleep(2)
+            
+            # Verify we're actually logged in by checking if we're still on login page
+            if "login" in self.driver.current_url.lower() or "signin" in self.driver.current_url.lower():
+                self.logger.error("Still on login page after login attempt. Login failed.")
+                return []
 
         try:
             # Check for page not found


### PR DESCRIPTION
Add verification after login attempts to ensure scraper properly bails out when authentication fails, preventing wasted processing time on failed sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)