### PR TITLE
fix: Include timestamp in JobQuoteChatSerializer for chat message dat…

### DIFF
--- a/apps/job/serializers/job_quote_chat_serializer.py
+++ b/apps/job/serializers/job_quote_chat_serializer.py
@@ -11,8 +11,14 @@ class JobQuoteChatSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = JobQuoteChat
-        fields = ["message_id", "role", "content", "metadata"]
-        extra_kwargs = {"metadata": {"default": dict, "required": False}}
+        # Expose the server-generated `timestamp` so the frontend
+        # can display message date/time, but mark it read-only so
+        # clients cannot alter it.
+        fields = ["message_id", "role", "content", "metadata", "timestamp"]
+        extra_kwargs = {
+            "metadata": {"default": dict, "required": False},
+            "timestamp": {"read_only": True},
+        }
 
     def validate_role(self, value):
         """Validate that role is either 'user' or 'assistant'."""


### PR DESCRIPTION
…e/time display

- Add timestamp field to JobQuoteChatSerializer output fields
- Mark timestamp as read_only to prevent client modification
- Fix missing date/time display at bottom of chat messages in frontend

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
