### PR TITLE
serialiser bugfix - job number is a number

### DIFF
--- a/apps/job/serializers/kanban_serializer.py
+++ b/apps/job/serializers/kanban_serializer.py
@@ -44,7 +44,7 @@ class KanbanErrorResponseSerializer(serializers.Serializer):
 class JobSearchFiltersSerializer(serializers.Serializer):
     """Serializer for advanced search filters."""
 
-    job_number = serializers.CharField(required=False, allow_blank=True)
+    job_number = serializers.IntegerField(required=False, allow_null=True)
     name = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     client_name = serializers.CharField(required=False, allow_blank=True)
@@ -73,7 +73,7 @@ class KanbanJobSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     name = serializers.CharField()
     description = serializers.CharField(allow_blank=True, allow_null=True)
-    job_number = serializers.CharField()
+    job_number = serializers.IntegerField()
 
     # Client and contact info
     client_name = serializers.CharField(allow_blank=True)
@@ -144,7 +144,7 @@ class KanbanColumnJobSerializer(serializers.Serializer):
 
     # Basic job info
     id = serializers.CharField()  # Converted to string by service
-    job_number = serializers.CharField()
+    job_number = serializers.IntegerField()
     name = serializers.CharField()
     description = serializers.CharField(allow_blank=True, allow_null=True)
 


### PR DESCRIPTION
## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
