### PR TITLE
Add AWS EC2 instance management for UAT server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@ GCP_CREDENTIALS="/path/to/google-service-account-key.json"
 STEEL_TUBE_USERNAME=REQUEST_FROM_STEEL_AND_TUBE
 STEEL_TUBE_PASSWORD="REQUEST_FROM_STEEL_AND_TUBE"
 
+# For remote starting UAT
+UAT_AWS_KEY="YOUR_AWS_ACCESS_KEY_ID_HERE"
+UAT_AWS_SECRET="YOUR_AWS_SECRET_ACCESS_KEY_HERE"
+UAT_AWS_REGION="ap-southeast-2"
+UAT_INSTANCE_ID="i-0123456789abcdef0"  # Replace with your actual UAT instance ID
+
 # Email Configuration (for password reset, etc.)
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587

--- a/apps/workflow/services/__init__.py
+++ b/apps/workflow/services/__init__.py
@@ -5,6 +5,7 @@ try:
     from django.apps import apps
 
     if apps.ready:
+        from .aws_service import AWSService
         from .company_defaults_service import get_company_defaults
         from .error_persistence import (
             extract_job_context,
@@ -19,6 +20,7 @@ except (ImportError, RuntimeError):
     pass
 
 __all__ = [
+    "AWSService",
     "XeroSyncService",
     "extract_job_context",
     "extract_request_context",

--- a/apps/workflow/services/aws_service.py
+++ b/apps/workflow/services/aws_service.py
@@ -1,0 +1,217 @@
+"""
+AWS EC2 Instance Management Service
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+class AWSService:
+    """Service for managing AWS EC2 instances"""
+
+    def __init__(self):
+        self.aws_access_key_id = os.environ.get("UAT_AWS_KEY")
+        self.aws_secret_access_key = os.environ.get("UAT_AWS_SECRET")
+        self.aws_region = os.environ.get("UAT_AWS_REGION", "ap-southeast-2")
+        self.uat_instance_id = os.environ.get("UAT_INSTANCE_ID")
+
+        if not self.aws_access_key_id or not self.aws_secret_access_key:
+            raise ValueError("AWS credentials not found in environment variables")
+
+        if not self.uat_instance_id:
+            raise ValueError("UAT_INSTANCE_ID not found in environment variables")
+
+    def _get_ec2_client(self):
+        """Get authenticated EC2 client"""
+        return boto3.client(
+            "ec2",
+            region_name=self.aws_region,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        )
+
+    def get_instance_status(self) -> Dict[str, Any]:
+        """Get current status of the UAT instance"""
+        try:
+            ec2 = self._get_ec2_client()
+            response = ec2.describe_instances(InstanceIds=[self.uat_instance_id])
+
+            instance = response["Reservations"][0]["Instances"][0]
+
+            return {
+                "success": True,
+                "instance_id": self.uat_instance_id,
+                "state": instance["State"]["Name"],
+                "instance_type": instance["InstanceType"],
+                "public_ip": instance.get("PublicIpAddress"),
+                "private_ip": instance.get("PrivateIpAddress"),
+                "launch_time": instance.get("LaunchTime"),
+                "region": self.aws_region,
+            }
+
+        except ClientError as e:
+            logger.error(
+                f"AWS error getting instance status: {e.response['Error']['Message']}"
+            )
+            return {
+                "success": False,
+                "error": e.response["Error"]["Message"],
+                "error_code": e.response["Error"]["Code"],
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error getting instance status: {str(e)}")
+            return {"success": False, "error": str(e)}
+
+    def start_instance(self) -> Dict[str, Any]:
+        """Start the UAT instance"""
+        try:
+            # First check current status
+            status = self.get_instance_status()
+            if not status["success"]:
+                return status
+
+            if status["state"] == "running":
+                return {
+                    "success": True,
+                    "message": "Instance is already running",
+                    "instance_id": self.uat_instance_id,
+                    "state": "running",
+                    "public_ip": status.get("public_ip"),
+                }
+
+            if status["state"] not in ["stopped", "stopping"]:
+                return {
+                    "success": False,
+                    "error": (
+                        f'Instance is in {status["state"]} state and cannot be '
+                        "started"
+                    ),
+                }
+
+            # Start the instance
+            ec2 = self._get_ec2_client()
+            response = ec2.start_instances(InstanceIds=[self.uat_instance_id])
+
+            starting_instance = response["StartingInstances"][0]
+
+            return {
+                "success": True,
+                "message": "Instance start initiated successfully",
+                "instance_id": self.uat_instance_id,
+                "previous_state": starting_instance["PreviousState"]["Name"],
+                "current_state": starting_instance["CurrentState"]["Name"],
+                "state_transition_reason": response.get("StateTransitionReason"),
+            }
+
+        except ClientError as e:
+            logger.error(
+                f"AWS error starting instance: {e.response['Error']['Message']}"
+            )
+            return {
+                "success": False,
+                "error": e.response["Error"]["Message"],
+                "error_code": e.response["Error"]["Code"],
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error starting instance: {str(e)}")
+            return {"success": False, "error": str(e)}
+
+    def stop_instance(self) -> Dict[str, Any]:
+        """Stop the UAT instance"""
+        try:
+            # First check current status
+            status = self.get_instance_status()
+            if not status["success"]:
+                return status
+
+            if status["state"] == "stopped":
+                return {
+                    "success": True,
+                    "message": "Instance is already stopped",
+                    "instance_id": self.uat_instance_id,
+                    "state": "stopped",
+                }
+
+            if status["state"] not in ["running", "stopping"]:
+                return {
+                    "success": False,
+                    "error": (
+                        f'Instance is in {status["state"]} state and cannot be '
+                        "stopped"
+                    ),
+                }
+
+            # Stop the instance
+            ec2 = self._get_ec2_client()
+            response = ec2.stop_instances(InstanceIds=[self.uat_instance_id])
+
+            stopping_instance = response["StoppingInstances"][0]
+
+            return {
+                "success": True,
+                "message": "Instance stop initiated successfully",
+                "instance_id": self.uat_instance_id,
+                "previous_state": stopping_instance["PreviousState"]["Name"],
+                "current_state": stopping_instance["CurrentState"]["Name"],
+                "state_transition_reason": response.get("StateTransitionReason"),
+            }
+
+        except ClientError as e:
+            logger.error(
+                f"AWS error stopping instance: {e.response['Error']['Message']}"
+            )
+            return {
+                "success": False,
+                "error": e.response["Error"]["Message"],
+                "error_code": e.response["Error"]["Code"],
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error stopping instance: {str(e)}")
+            return {"success": False, "error": str(e)}
+
+    def reboot_instance(self) -> Dict[str, Any]:
+        """Reboot the UAT instance"""
+        try:
+            # First check current status
+            status = self.get_instance_status()
+            if not status["success"]:
+                return status
+
+            if status["state"] != "running":
+                return {
+                    "success": False,
+                    "error": (
+                        f'Instance is in {status["state"]} state and cannot be '
+                        "rebooted. Instance must be running to reboot."
+                    ),
+                }
+
+            # Reboot the instance
+            ec2 = self._get_ec2_client()
+            ec2.reboot_instances(InstanceIds=[self.uat_instance_id])
+
+            return {
+                "success": True,
+                "message": "Instance reboot initiated successfully",
+                "instance_id": self.uat_instance_id,
+                "state": "rebooting",
+            }
+
+        except ClientError as e:
+            logger.error(
+                f"AWS error rebooting instance: {e.response['Error']['Message']}"
+            )
+            return {
+                "success": False,
+                "error": e.response["Error"]["Message"],
+                "error_code": e.response["Error"]["Code"],
+            }
+        except Exception as e:
+            logger.error(f"Unexpected error rebooting instance: {str(e)}")
+            return {"success": False, "error": str(e)}

--- a/apps/workflow/urls.py
+++ b/apps/workflow/urls.py
@@ -48,6 +48,13 @@ from apps.workflow.views.app_error_view import (
     AppErrorListAPIView,
     AppErrorViewSet,
 )
+from apps.workflow.views.aws_instance_view import (
+    AWSInstanceManagementView,
+    get_instance_status,
+    reboot_instance,
+    start_instance,
+    stop_instance,
+)
 from apps.workflow.views.company_defaults_api import CompanyDefaultsAPIView
 from apps.workflow.views.xero import xero_view
 from apps.workflow.xero_webhooks import XeroWebhookView
@@ -66,6 +73,15 @@ home_pattern.functional_group = "Main Redirect"  # type: ignore[attr-defined]
 urlpatterns = [
     # Redirect to Kanban board
     home_pattern,
+    path(
+        "api/aws/instance/",
+        AWSInstanceManagementView.as_view(),
+        name="aws_instance_management",
+    ),
+    path("api/aws/instance/status/", get_instance_status, name="aws_instance_status"),
+    path("api/aws/instance/start/", start_instance, name="aws_instance_start"),
+    path("api/aws/instance/stop/", stop_instance, name="aws_instance_stop"),
+    path("api/aws/instance/reboot/", reboot_instance, name="aws_instance_reboot"),
     path("api/enums/<str:enum_name>/", get_enum_choices, name="get_enum_choices"),
     path(
         "api/xero/authenticate/",

--- a/apps/workflow/views/aws_instance_view.py
+++ b/apps/workflow/views/aws_instance_view.py
@@ -1,0 +1,230 @@
+"""
+AWS Instance Management API Views
+"""
+
+import json
+import logging
+
+from django.http import JsonResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from apps.workflow.services.aws_service import AWSService
+from apps.workflow.services.error_persistence import persist_app_error
+
+logger = logging.getLogger(__name__)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def get_instance_status(request):
+    """Get current status of the UAT instance"""
+    try:
+        aws_service = AWSService()
+        result = aws_service.get_instance_status()
+
+        if result["success"]:
+            return Response(result, status=status.HTTP_200_OK)
+        else:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+    except ValueError as e:
+        logger.error(f"Configuration error: {str(e)}")
+        return Response(
+            {"success": False, "error": "AWS configuration error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error getting instance status: {str(e)}")
+        persist_app_error(e)
+        return Response(
+            {"success": False, "error": "Internal server error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def start_instance(request):
+    """Start the UAT instance"""
+    try:
+        aws_service = AWSService()
+        result = aws_service.start_instance()
+
+        if result["success"]:
+            logger.info(f"Instance start initiated by user {request.user.email}")
+            return Response(result, status=status.HTTP_200_OK)
+        else:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+    except ValueError as e:
+        logger.error(f"Configuration error: {str(e)}")
+        return Response(
+            {"success": False, "error": "AWS configuration error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error starting instance: {str(e)}")
+        persist_app_error(e)
+        return Response(
+            {"success": False, "error": "Internal server error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def stop_instance(request):
+    """Stop the UAT instance"""
+    try:
+        aws_service = AWSService()
+        result = aws_service.stop_instance()
+
+        if result["success"]:
+            logger.info(f"Instance stop initiated by user {request.user.email}")
+            return Response(result, status=status.HTTP_200_OK)
+        else:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+    except ValueError as e:
+        logger.error(f"Configuration error: {str(e)}")
+        return Response(
+            {"success": False, "error": "AWS configuration error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error stopping instance: {str(e)}")
+        persist_app_error(e)
+        return Response(
+            {"success": False, "error": "Internal server error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def reboot_instance(request):
+    """Reboot the UAT instance"""
+    try:
+        aws_service = AWSService()
+        result = aws_service.reboot_instance()
+
+        if result["success"]:
+            logger.info(f"Instance reboot initiated by user {request.user.email}")
+            return Response(result, status=status.HTTP_200_OK)
+        else:
+            return Response(result, status=status.HTTP_400_BAD_REQUEST)
+
+    except ValueError as e:
+        logger.error(f"Configuration error: {str(e)}")
+        return Response(
+            {"success": False, "error": "AWS configuration error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error rebooting instance: {str(e)}")
+        persist_app_error(e)
+        return Response(
+            {"success": False, "error": "Internal server error", "details": str(e)},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AWSInstanceManagementView(View):
+    """
+    Combined view for AWS instance management operations
+    Handles all instance operations through a single endpoint with action parameter
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        """Ensure user is authenticated before processing any requests"""
+        if not request.user.is_authenticated:
+            return JsonResponse(
+                {"success": False, "error": "Authentication required"}, status=401
+            )
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request):
+        """Get instance status"""
+        return self._handle_request(request, "status")
+
+    def post(self, request):
+        """Handle POST requests for instance operations"""
+        try:
+            data = json.loads(request.body) if request.body else {}
+            action = data.get("action", request.GET.get("action"))
+
+            if not action:
+                return JsonResponse(
+                    {"success": False, "error": "Action parameter is required"},
+                    status=400,
+                )
+
+            return self._handle_request(request, action)
+
+        except json.JSONDecodeError:
+            return JsonResponse(
+                {"success": False, "error": "Invalid JSON in request body"}, status=400
+            )
+
+    def _handle_request(self, request, action):
+        """Handle the actual AWS operation based on action"""
+        try:
+            aws_service = AWSService()
+
+            if action == "status":
+                result = aws_service.get_instance_status()
+            elif action == "start":
+                result = aws_service.start_instance()
+                if result["success"]:
+                    logger.info(
+                        f"Instance start initiated by user {request.user.email}"
+                    )
+            elif action == "stop":
+                result = aws_service.stop_instance()
+                if result["success"]:
+                    logger.info(f"Instance stop initiated by user {request.user.email}")
+            elif action == "reboot":
+                result = aws_service.reboot_instance()
+                if result["success"]:
+                    logger.info(
+                        f"Instance reboot initiated by user {request.user.email}"
+                    )
+            else:
+                return JsonResponse(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Unknown action: {action}. Valid actions are: "
+                            "status, start, stop, reboot"
+                        ),
+                    },
+                    status=400,
+                )
+
+            status_code = 200 if result["success"] else 400
+            return JsonResponse(result, status=status_code)
+
+        except ValueError as e:
+            logger.error(f"Configuration error: {str(e)}")
+            return JsonResponse(
+                {
+                    "success": False,
+                    "error": "AWS configuration error",
+                    "details": str(e),
+                },
+                status=500,
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error in AWS operation '{action}': {str(e)}")
+            persist_app_error(e)
+            return JsonResponse(
+                {"success": False, "error": "Internal server error", "details": str(e)},
+                status=500,
+            )

--- a/docs/urls/workflow.md
+++ b/docs/urls/workflow.md
@@ -4,6 +4,15 @@
 
 ## API Endpoints
 
+#### Aws Management
+| URL Pattern | View | Name | Description |
+|-------------|------|------|-------------|
+| `/api/aws/instance/` | `aws_instance_view.AWSInstanceManagementView` | `aws_instance_management` | Combined view for AWS instance management operations |
+| `/api/aws/instance/reboot/` | `aws_instance_view.reboot_instance` | `aws_instance_reboot` | Reboot the UAT instance |
+| `/api/aws/instance/start/` | `aws_instance_view.start_instance` | `aws_instance_start` | Start the UAT instance |
+| `/api/aws/instance/status/` | `aws_instance_view.get_instance_status` | `aws_instance_status` | Get current status of the UAT instance |
+| `/api/aws/instance/stop/` | `aws_instance_view.stop_instance` | `aws_instance_stop` | Stop the UAT instance |
+
 #### System
 | URL Pattern | View | Name | Description |
 |-------------|------|------|-------------|

--- a/poetry.lock
+++ b/poetry.lock
@@ -233,6 +233,46 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.39.4"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.39.4-py3-none-any.whl", hash = "sha256:f8e9534b429121aa5c5b7c685c6a94dd33edf14f87926e9a182d5b50220ba284"},
+    {file = "boto3-1.39.4.tar.gz", hash = "sha256:6c955729a1d70181bc8368e02a7d3f350884290def63815ebca8408ee6d47571"},
+]
+
+[package.dependencies]
+botocore = ">=1.39.4,<1.40.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.13.0,<0.14.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.39.4"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "botocore-1.39.4-py3-none-any.whl", hash = "sha256:c41e167ce01cfd1973c3fa9856ef5244a51ddf9c82cb131120d8617913b6812a"},
+    {file = "botocore-1.39.4.tar.gz", hash = "sha256:e662ac35c681f7942a93f2ec7b4cde8f8b56dd399da47a79fa3e370338521a56"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.23.8)"]
+
+[[package]]
 name = "cachetools"
 version = "5.5.1"
 description = "Extensible memoizing collections and decorators"
@@ -1867,6 +1907,18 @@ files = [
     {file = "jiter-0.10.0-cp39-cp39-win32.whl", hash = "sha256:5f51e048540dd27f204ff4a87f5d79294ea0aa3aa552aca34934588cf27023cf"},
     {file = "jiter-0.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:1b28302349dc65703a9e4ead16f163b1c339efffbe1049c30a44b001a2a4fff9"},
     {file = "jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500"},
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 
 [[package]]
@@ -3976,6 +4028,24 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.13.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be"},
+    {file = "s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "selenium"
 version = "4.34.2"
 description = "Official Python bindings for Selenium WebDriver"
@@ -4613,4 +4683,4 @@ urllib3 = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "045b3b44dec93eefc621c1a8f33a6e58116718688f2fc6b7322d5aafb25c6295"
+content-hash = "0da0b4dc610eda077cbbdd7d186f753fce884acfa5e5dbea82355aabf1efc15a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ pre-commit = "^4.2.0"
 django-stubs = "^5.2.1"
 drf-spectacular = "^0.28.0"
 httpcore = "^1.0.9"
+boto3 = "^1.39.4"
 
 [tool.poetry.scripts]
 post-install = "scripts.post_install:install_system_deps"  # Script to install system dependencies like poppler-utils


### PR DESCRIPTION
## Summary
- Add remote start/stop/reboot functionality for UAT instance through web interface
- Implement AWSService for EC2 instance management operations  
- Add API endpoints for instance status, start, stop, reboot operations
- Add boto3 dependency for AWS SDK integration
- Configure environment variables for UAT AWS credentials and instance ID

## API Endpoints Added
- `GET /api/aws/instance/status/` - Get current instance status
- `POST /api/aws/instance/start/` - Start the UAT instance
- `POST /api/aws/instance/stop/` - Stop the UAT instance  
- `POST /api/aws/instance/reboot/` - Reboot the UAT instance
- `POST /api/aws/instance/` - Combined endpoint with action parameter

## Test Plan
- [x] Test AWS credentials and connectivity
- [x] Test instance status retrieval
- [x] Test instance start operation
- [x] Test API endpoints with authentication
- [x] Test error handling and user logging
- [x] Test frontend integration (confirmed working)

## Environment Variables Required
Add these to your `.env` file:
```
UAT_AWS_KEY="your_aws_access_key"
UAT_AWS_SECRET="your_aws_secret_key"
UAT_AWS_REGION="ap-southeast-2"
UAT_INSTANCE_ID="i-0813c6ab52e0f96d4"
```

🤖 Generated with [Claude Code](https://claude.ai/code)