### PR TITLE
Fix database user environment variable naming consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ ALLOWED_HOSTS=localhost,127.0.0.1,your-domain.ngrok-free.app
 
 # Database Configuration
 MYSQL_DATABASE=msm_workflow
-MSM_DB_USER=root
+MYSQL_DB_USER=root
 DB_PASSWORD=your_secure_password_here
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/docs/backup-restore-process.md
+++ b/docs/backup-restore-process.md
@@ -56,15 +56,15 @@ ls -la restore/
 **Run as:** Development system user
 **Check:**
 ```bash
-grep -E "^(MYSQL_DATABASE|MSM_DB_USER|DB_PASSWORD|DB_HOST|DB_PORT)=" .env
+grep -E "^(MYSQL_DATABASE|MYSQL_DB_USER|DB_PASSWORD|DB_HOST|DB_PORT)=" .env
 export DB_PASSWORD=$(grep DB_PASSWORD .env | cut -d= -f2)
 export MYSQL_DATABASE=$(grep MYSQL_DATABASE .env | cut -d= -f2)
-export MSM_DB_USER=$(grep MSM_DB_USER .env | cut -d= -f2)
+export MYSQL_DB_USER=$(grep MYSQL_DB_USER .env | cut -d= -f2)
 ```
 **Must show:**
 ```
 MYSQL_DATABASE=msm_workflow
-MSM_DB_USER=django_user
+MYSQL_DB_USER=django_user
 DB_PASSWORD=your_dev_password
 DB_HOST=localhost
 DB_PORT=3306
@@ -91,7 +91,7 @@ MYSQL_PWD=your_dev_password mysql -u django_user -e "SHOW DATABASES;" | grep msm
 **Run as:** Development system user
 **Command:**
 ```bash
-MYSQL_PWD=$DB_PASSWORD mysql -u $MSM_DB_USER $MYSQL_DATABASE --execute="source restore/prod_backup_YYYYMMDD_HHMMSS_schema.sql"
+MYSQL_PWD=$DB_PASSWORD mysql -u $MYSQL_DB_USER $MYSQL_DATABASE --execute="source restore/prod_backup_YYYYMMDD_HHMMSS_schema.sql"
 ```
 **Check:**
 ```bash
@@ -130,7 +130,7 @@ grep "INSERT INTO" restore/prod_backup_YYYYMMDD_HHMMSS.sql | wc -l
 **Run as:** Development system user
 **Command:**
 ```bash
-MYSQL_PWD=$DB_PASSWORD mysql -u $MSM_DB_USER $MYSQL_DATABASE --execute="source restore/prod_backup_YYYYMMDD_HHMMSS.sql"
+MYSQL_PWD=$DB_PASSWORD mysql -u $MYSQL_DB_USER $MYSQL_DATABASE --execute="source restore/prod_backup_YYYYMMDD_HHMMSS.sql"
 ```
 **Check:**
 ```bash

--- a/jobs_manager/settings/base.py
+++ b/jobs_manager/settings/base.py
@@ -325,7 +325,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
         "NAME": os.getenv("MYSQL_DATABASE"),
-        "USER": os.getenv("MSM_DB_USER"),
+        "USER": os.getenv("MYSQL_DB_USER"),
         "PASSWORD": os.getenv("DB_PASSWORD"),
         "HOST": os.getenv("DB_HOST"),
         "PORT": os.getenv("DB_PORT"),


### PR DESCRIPTION
## Summary
- Standardize database user environment variable to `MYSQL_DB_USER` across all configuration files
- Resolve database access issues where settings.py was looking for `MSM_DB_USER` while .env files used `MYSQL_DB_USER`
- Update documentation to reference correct variable names

## Test plan
- [x] Verify database connection works with corrected environment variable
- [x] Check that settings properly load `MYSQL_DB_USER` from .env
- [x] Confirm documentation matches actual implementation

🤖 Generated with [Claude Code](https://claude.ai/code)