### PR TITLE
fix/purchase orders

### DIFF
--- a/apps/purchasing/views/purchasing_rest_views.py
+++ b/apps/purchasing/views/purchasing_rest_views.py
@@ -193,7 +193,13 @@ class PurchaseOrderListCreateRestView(APIView):
             return PurchaseOrderCreateSerializer
         return PurchaseOrderListSerializer
 
-    @extend_schema(operation_id="listPurchaseOrders")
+    @extend_schema(
+        operation_id="listPurchaseOrders",
+        responses={
+            status.HTTP_200_OK: PurchaseOrderListSerializer(many=True),
+            status.HTTP_400_BAD_REQUEST: "Invalid input data",
+        },
+    )
     def get(self, request):
         """Get list of purchase orders with optional status filtering."""
         status_filter = request.query_params.get("status", None)
@@ -304,6 +310,12 @@ class DeliveryReceiptRestView(APIView):
 
     serializer_class = DeliveryReceiptRequestSerializer
 
+    @extend_schema(
+        responses={
+            status.HTTP_200_OK: DeliveryReceiptResponseSerializer,
+            status.HTTP_400_BAD_REQUEST: DeliveryReceiptResponseSerializer,
+        }
+    )
     def post(self, request):
         try:
             # Validate input data
@@ -455,6 +467,8 @@ class StockConsumeRestView(APIView):
         # (But stock alocation in JobActualTab might override default values for cost and revenue)
         unit_cost = request.data.get("unit_cost", None)
         unit_rev = request.data.get("unit_rev", None)
+        cost_dec = None
+        revenue_dec = None
 
         try:
             if unit_cost is not None:

--- a/apps/timesheet/views/api.py
+++ b/apps/timesheet/views/api.py
@@ -102,7 +102,7 @@ class StaffListAPIView(APIView):
                             if member.wage_rate
                             else Decimal(0)
                         ),
-                        "avatarUrl": None,  # Add avatar logic if needed
+                        "avatarUrl": None,  # TODO: add avatar logic
                     }
                 )
 


### PR DESCRIPTION
- **refactor: fix broken Quote Import feature by restoring original functions of import_quote_service**
- **feat(client): optimize client list endpoint for dropdowns**
- **refactor(kanban_service.py): change ordering of jobs by priority**
- **fix(job): change job_id type in reorder url from str to uuid feat: remove import_quote_guide.md**
- **lint**
- **refactor(job_rest_views.py): improve job update process**
- **feat(quote_sync_service.py): prioritize quote data over estimate data when pre-populating quote sheet**
- **feat(google_sheets.py): populate labour_minutes from quantity if missing**
- **feat(apps/job/serializers): Add Invoice and Quote serializers**
- **feat(accounts): implement staff API endpoints with permissions**
- **feat(xero_view.py): add csrf_exempt decorator to POST endpoints**
- **refactor(accounts): rename IsSuperUser permission to IsStaff**
- **feat(job): enhance JobSerializer with invoice and quote serializers**
- **Move from ngrok to localtunnel**
- **feat: Implement JWT authentication and frontend redirection**
- **feat(xero): add xero_ping endpoint to check Xero connection status**
- **feat(xero_view.py): add csrf_exempt decorator to all views feat(xero_view.py): add require_GET decorator to stream_xero_sync view**
- **feat(middleware.py): return 401 JSON for API endpoints when not authenticated**
- **feat(middleware.py): return 401 JSON for API endpoints when user is not authenticated**
- **refactor(jobs_manager/authentication.py): Add logging to JWTAuthentication**
- **refactor(jobs_manager/authentication.py): change log level from debug to info for better clarity**
- **feat(jobs_manager/authentication.py): enhance JWT authentication**
- **refactor(jobs_manager): remove unnecessary middleware**
- **refactor(jobs_manager/authentication.py): Remove unnecessary print and log statements**
- **refactor(xero/sync.py): Improve handling of client association for invoices, bills, and credit notes**
- **refactor(apps/workflow/api/xero/sync.py): improve code readability and maintainability by extracting common logic into a helper function**
- **refactor(apps/workflow/api/xero/sync.py): Improve stock transformation**
- **refactor(xero/sync.py): simplify get_or_create calls for models**
- **feat(accounts): add preferred_name field to UserProfileSerializer**
- **fix(xero/sync.py): map Xero PO statuses to internal statuses**
- **feat(.env.example): add COOKIE_SAMESITE and FRONT_END_URL to .env.example feat(accounts/serializers.py): allow password updates and handle empty group/permission lists feat(accounts/views/staff_api.py): add logging for staff update view feat(accounts/views/token_view.py): add COOKIE_SAMESITE env variable support feat(client/views/client_rest_views.py): create client in Xero first, then sync locally feat(workflow/views/xero/xero_invoice_manager.py): improve error message for missing CostSet feat(workflow/views/xero/xero_quote_manager.py): improve error message for missing CostSet feat(jobs_manager/authentication.py): add logging to authentication feat(jobs_manager/settings/base.py): load dotenv before accessing env variables**
- **feat: add django-apscheduler jobs api endpoints**
- **feat(apps/accounts/views/token_view.py): Add logging to token view for better debugging and monitoring.**
- **feat(job): Enhance Job Serializer with Quote and Invoice Details**
- **Refine month-end API and add integration guide**
- **Refine stock sync validation and update docs**
- **Refactor Xero sync validation and error helpers**
- **Add paginator limiting Xero errors**
- **Refactor Xero item processing**
- **Add missing docstrings and return value**
- **move xero error views**
- **Update integration docs to match new error URLs**
- **Remove unused XeroProcessingError**
- **feat(xero): enhance xero sync progress tracking and reporting**
- **fix(xero_webhooks.py): replace get_solo() with get_instance()**
- **feat(xero_webhooks.py): pass tenant_id to XeroSyncService init**
- **feat(sync.py): add recordsUpdated field to sync log message**
- **feat(workflow): implement error persistence and logging for Xero feat(workflow): add AppError and XeroError models for tracking errors feat(workflow): enhance Xero integration with detailed error handling fix(workflow): correct import order in models/__init__.py feat(workflow): add logging for new Xero documents and clients**
- **fix(xero/sync.py): pass invoice type to set_invoice_or_bill_fields**
- **feat(xero): enhance client data sync from Xero**
- **feat(xero_sync_service.py): improve Xero tenant ID retrieval and token handling**
- **fix(xero_sync_service.py): update token update method to match Xero API client configuration**
- **feat(reprocess_xero.py): update additional contact persons name and add all_phones field**
- **feat(reprocess_xero.py): create ClientContact objects when reprocessing Xero data**
- **docs: describe new purchasing REST API**
- **Address feedback on purchasing refactor**
- **feat(purchasing): add item_code to PurchaseOrderLine for Xero integration feat(purchasing): add API endpoints for stock management feat(purchasing): add PurchaseOrderDetailRestView to retrieve full PO details feat(workflow): add migration for AppError model options and id field refactor(purchasing): move PurchaseOrderLine model definition to models.py**
- **wrap up**
- **chore: lint**
- **fix(accounts): handle empty group/permission lists in StaffSerializer**
- **chore: delete import_quote_guid.md**
- **feat(purchasing): enhance purchase order management**
- **Claude PR Assistant workflow**
- **Claude Code Review workflow**
- **Handle non-tracked inventory too**
- **Linting**
- **Restored job contact name**
- **old cfield names**
- **More typo stuff**
- **fix(backport_data_restore.py): specify encoding for file opening to support utf-8 characters feat(fix_job_id_constraint_removal.py): correct table name in command help and queries fix(edit_job_form_autosave.js): add change event listener to all autosave-input elements fix(initial_data.json): change workflow.client to client.client in initial data fixture**
- **git ignore added .DSStore**
- **Delete Steel_and_Tube json/csv files**
- **Removed unnecessary MacOS files from repo**
- **Fix circular imports**
- **Attempts to fix linting.  Not entirely successful**
- **Fixing the stock data model - we have unit revenue, not retail_rate**
- **Formatting**
- **Fix to syncing credit notes**
- **Xero sync running end-to-end**
- **Update apps/workflow/api/xero/sync.py**
- **basic linting**
- **Fixed exclusions.  I've got a lot of linting issues but not that many**
- **Removed emojis**
- **Cleanup old plans**
- **Changed sync back to hourly**
- **Tweaked plan to highlight that this is only backend**
- **Single scheduler**
- **Lint related**
- **Linting**
- **Linting**
- **More linting**
- **Yet more linting**
- **More autogenerated documentation**
- **More docs**
- **Approaching the end of the automated documentation ticket**
- **Finished AI written documentation**
- **Various doc fixes.**
- **More autogenerated docs**
- **Yet more autogenerated docstrings**
- **Nearly the end of autogenerated docs**
- **I'd like to say that'll do but I keep discovering little issues :-(**
- **feat: Implement LLM integration for chatbot with AI provider management**
- **feat: Switch from Claude to Gemini for chat functionality**
- **fix: Add role mapping for Gemini API compatibility**
- **fix: Configure JobQuoteChatInteractionView for proper HTTP method handling**
- **fix: Resolve URL routing conflict for chat interaction endpoint**
- **fix: Remove explicit authentication classes from JobQuoteChatInteractionView**
- **docs: Add comprehensive Gemini chat implementation guide**
- **Linting and other minor changes**
- **That's enough**
- **More eliminating print**
- **More print removed -e nough for now**
- **More logs**
- **Yet more logs**
- **kinda working.**
- **feat: Enhance chat metadata with comprehensive prompt context**
- **fix(gemini): ensure metadata JSON-serialisable (tool_definitions)**
- **chore(prompt): include job number and id in system prompt for Gemini**
- **fix: Include timestamp in JobQuoteChatSerializer for chat message date/time display**
- **fix: Include timestamp in JobQuoteChatSerializer for chat message date/time display**
- **feat(create_shop_jobs.py): prevent duplicate shop job creation feat(purchase_order_email_service.py): improve error handling for missing supplier email feat(purchasing_rest_service.py): add supplier_id to purchase order data and handle supplier updates feat(purchase_order.py): improve error handling and messaging for email and PDF generation feat(purchasing_rest_views.py): support multiple status filters for purchase orders feat(xero_po_manager.py): improve Xero purchase order synchronization and error handling**
- **Good progress on the restore.  Not 100% there yet**
- **Added migrations to the backup/restore**
- **Tracking pretty well**
- **Small simplification**
- **Formatting**
- **More linting**
- **Yet more linting**
- **More**
- **Yet more linting**
- **More linting**
- **AND MORE!**
- **a bit sick of linting**
- **last commit in branch before closing**
- **docs(CLAUDE.md): document new costing architecture and deprecate old models feat(CLAUDE.md): add CostSet/CostLine documentation and migration guide fix(CLAUDE.md): update job lifecycle workflow and business rules feat(CLAUDE.md): add critical architecture guidelines for new development feat(CLAUDE.md): add complete migration strategy for legacy models feat(CLAUDE.md): add service layer patterns for costing and job management feat(create_shop_jobs.py): simplify shop job creation command feat(create_shop_jobs.py): remove job existence check for shop jobs feat(create_shop_jobs.py): set default values for shop job fields feat(urls_rest.py): remove unused imports and comments**
- **fix(purchasing): optimize PO detail view queryset**
- **feat: various improvements and fixes across multiple apps**
- **Small improvements to the KPI**
- **Linter tweaks**
- **Finished linting**
- **feat(purchasing): implement delivery receipt allocations**
- **chore: delete unused template/js files**
- **refactor(job_serializer.py): remove legacy JobPricing fields and validation**
- **feat: add APScheduler as a systemd daemon**
- **feat(apps/purchasing/views/purchase_order.py): return JSON response after quote processing refactor(apps/quoting/apps.py): remove scheduler start from apps refactor(apps/workflow/apps.py): remove scheduler start from apps**
- **feat(purchasing): enhance AI provider selection for quote processing**
- **fix(run_scheduler.py): remove force=True argument from start_scheduler function call**
- **Wrote job aging plan**
- **feat(job): remove legacy pricing system and migrate to CostSet/CostLine**
- **Add JobAgingService with comprehensive error handling**
- **Add JobAgingAPIView for job aging report endpoint**
- **Add job aging API endpoint to URLs**
- **Job aging backend written**
- **Removed already impelemnted plan**
- **feat(job): migrate pricing to costing and cleanup legacy data feat(job): remove legacy pricing code from job serializers and services feat(timesheet): remove timeentry model**
- **Slighty better error reporting**
- **Fix to migration to handle historical month end**
- **Small tidying**
- **Commit 1: Enhanced AppError model with contextual fields**
- **feat(accounts): add OpenAPI schema generation and JWT cookie auth**
- **feat(job): add kanban functionality and serializers refactor(job): improve job quote chat API with serializers**
- **feat(serializers.py): add serializers for quote sync views feat(serializers.py): add serializers for job rest views feat(serializers.py): add serializers for job file views feat(serializers.py): add serializers for costing views feat(serializers.py): add serializers for xero views feat(views.py): implement serializers for job rest views feat(views.py): implement serializers for job file views feat(views.py): implement serializers for costing views feat(views.py): implement serializers for quote sync views feat(views.py): implement serializers for xero views refactor(views.py): use serializers for responses in job views refactor(views.py): use serializers for responses in quote sync views refactor(views.py): use serializers for responses in xero views refactor(serializers.py): add type hints to KanbanStaffSerializer and UserProfileSerializer**
- **feat: Remove all legacy function-based views and modernize to APIView**
- **Update plan: Mark commit 1 as completed with implementation notes**
- **Commit 2: Enhanced error persistence service with context utilities**
- **Update plan: Mark commit 2 as completed**
- **Commit 3: Enhanced error handling for high-priority services**
- **Update plan: Mark commit 3 as completed with implementation notes**
- **Commit 4: Enhanced API views and remaining service layer error handling**
- **Commit 5: AppError API endpoints with comprehensive filtering capabilities**
- **Final plan update: Mark all tasks completed with comprehensive summary**
- **Align on python version support**
- **Delete completed plans**
- **(work out why I'm seeing python 3.11 in github)**
- **Don't get claude to review every PR (too expensive)**
- **Linter**
- **Install poetry so it's easier to run tox**
- **Fix basic error**
- **feat(quote-chat): add MCP tool details backend infrastructure**
- **Key linting issues.**
- **More linting fixes**
- **linting (autoflake)**
- **linting**
- **More linting**
- **More linting**
- **Linting is so boring**
- **Fail early**
- **More fail early**
- **More linting fixes**
- **Linting done**
- **Set the paid flag automatically**
- **Linting**
- **More linting**
- **Implement refresh old prices feature for scrapers**
- **Fix missing ArchiveJobsRequestSerializer export**
- **Refresh probably working**
- **Update autogenerated init files**
- **Ticked one off**
- **Linting**
- **Automatic formatting test**
- **Test pre-commit hooks with auto-generated content updates**
- **Test commit for pre-commit hooks**
- **Fix update_init script to generate format-compatible imports and exit successfully**
- **Fixed 'click' version - was broken**
- **Apply pre-commit hook fixes**
- **Fix circular import in permissions and add type checking progress**
- **Add type annotations to workflow and accounts modules**
- **Continue adding type annotations across multiple modules**
- **Add type annotations to accounts, timesheet, and workflow modules**
- **Test pre-commit hooks after fix**
- **Fix pre-commit hook to run update_init.py with --all flag to prevent multiple instances**
- **Fix pre-commit hooks to use poetry environment**
- **Fix mypy type annotation error in urls.py**
- **upgraded ancient packages**
- **one more file with types**
- **Softer type rerquirements, shoudl make it easier**
- **Hopefully commit to the branch thsi time**
- **Lint stuff**
- **Fix mypy errors in accounting serializers**
- **Log progress**
- **Black formatting**
- **Bulk fix simple files and update progress tracking**
- **isort formatting fixes**
- **Fix mypy type annotations and configure Django stubs**
- **Fix StaffManager type annotations**
- **Fix tox configuration to install dev dependencies**
- **Add Staff Performance Report APIs**
- **Fix kanban serializer validation errors after production restore**
- **Complete production data restore process and fix critical issues**
- **serialiser bugfix - job number is a number**
- **More wrong data types - fixing**
- **Rewrite to pass testing**
- **Shared drives need an extra setting**
- **Enforcing typing**
- **Try and skip/ignore the secret key issue in github CI**
- **More linting**
- **Add comprehensive serializer testing script**
- **Add user activity tracking for UAT auto-shutdown**
- **Linting**
- **Cookies.txt is helpful for debugging**
- **Lint**
- **types aren't working**
- **Shop job API written**
- **Staff performance report**
- **Add shop_job field to comprehensive Job detail API**
- **Apply pre-commit formatting fixes**
- **Minor linting improvements**
- **more linting**
- **So sick of linting**
- **Add AWS EC2 instance management for UAT server**
- **feat(kanban): Implement simplified 6-column kanban system**
- **Add type annotations to helpers.py and implement PDF import functionality**
- **Fix database user environment variable naming consistency**
- **refactor(accounts): add logging to staff display name methods for debugging refactor(accounts): improve `get_display_full_name` readability refactor(accounts): add logging and null/empty first name check to `get_excluded_staff` refactor(accounts): add logging to `is_valid_uuid` for better debugging feat(accounts): add `actual_users` query parameter to StaffListAPIView fix(accounts): convert excluded staff IDs to UUIDs for filtering in StaffListAPIView refactor(accounts): rename `api_staff_list` URL to `api_staff_all_list` for clarity feat(job): add `rejected_flag` field to Job model feat(job): introduce new migration to update job statuses for simplified Kanban refactor(job): update `JOB_STATUS_CHOICES` and `STATUS_TOOLTIPS` for simplified Kanban refactor(job): remove legacy status choices from `JOB_STATUS_CHOICES` refactor(job): add `rejected_flag` to `KanbanJobSerializer` refactor(job): simplify Kanban column status retrieval in `KanbanService` refactor(job): update Kanban service tooltips to reflect simplified status refactor(job): remove unused imports from `job.importers.__init__.py` refactor(job): remove unused imports from `job.services.__init__.py` refactor(quoting): remove unused imports from `quoting.scrapers.__init__.py` refactor(workflow): remove unused imports from `workflow.views.xero.__init__.py` refactor(scripts): enhance `update_init.py` to exclude more directories and improve logging docs(accounts): update URL documentation for `api_staff_all_list`**
- **feat(schema): add client search query and job assignment request schema**
- **Update .gitignore to exclude personal environment setup files**
- **Fix CD workflow trigger and simplify Django settings**
- **refactor(project): Consolidate Django settings and quoting app views**
- **feat(kanban): Add Xero invoice number and ID search to advanced filter**
- **refactor(job): simplify job deletion logic by using latest_actual property feat(job): add rejected_flag field to Job and HistoricalJob models feat(job): update job statuses for simplified Kanban board fix(job): update pricing methodology choices for Job and HistoricalJob models**
- **Add UAT scheduler control via UAT_DISABLE_SCHEDULER environment variable**
- **Streamline CLAUDE.md and add UAT_DISABLE_SCHEDULER to .env.example**
- **feat: Enhance timesheet, job metrics, and Xero integration**
- **copy of UAT environment not in git as it contains slightly confidential stuff**
- **Better machine setup docs**
- **Dropbox - removed default**
- **CLeaner handling of start scheduler**
- **UAT version of deploy release**
- **geunicorn service done**
- **nginx conf**
- **frontend/backend splits for nginx**
- **Include frontend in release**
- **LINT**
- **feat: enhance quote system with acceptance workflow and revision management**
- **docs: update job.md, fix import error in accounting views**
- **Include logs folder (empty) in git**
- **Better debugging/start of handling the frontned backend truly able to run on different machines**
- **Plan for the new AWS setup**
- **Tweak to deploy script**
- **Add consolidated deployment script with fail-early validation**
- **Make deploy script executable**
- **Fix deploy script to detect virtual environment path**
- **Remove python check from prerequisites validation**
- **Remove all prerequisite validation checks**
- **Convert CostSet and CostLine models to use UUID primary keys**
- **Add UUID primary key to JobEvent model**
- **Remove legacy job status choices and cleanup**
- **Remove temporary debug logging and update gitignore**
- **jobevent is uuid too**
- **Add logging to auto_shutdown.sh script**
- **Fix auto_shutdown.sh to check for 'uat' hostname instead of 'scheduler'**
- **refactor: streamline module imports and enhance job detail serialization**
- **feat(api): Enhance quote sync, timesheet, and Xero integrations**
- **Implement staff date-based filtering system**
- **fix(job): resolve client contact data not updating in PUT requests**
- **refactor: change modified fields to match PR review.**
- **refactor(job_serializer): change file data array checking to prevent looping through an empty list.**
- **refactor(timesheet): Extract shared weekly timesheet response logic**
- **refactor(init): update __init__.py files to include new imports fix(pre-commit): exclude __init__.py files from isort to prevent conflicts fix(isort): update known_first_party to include 'apps' and 'jobs_manager' fix(update_init): handle encoding and newline styles when updating __init__.py files**
- **refactor: improve code readability and consistency across multiple files**
- **ci(workflow): trigger CI on all branches for push events The CI workflow previously only ran on pushes to `main` and `develop` branches. This change updates the workflow to trigger on pushes to any branch, allowing for earlier feedback on feature branches and other development branches.**
- **chore(pre-commit): Add and configure Python code quality tools**
- **style: ignore E501 and E203 Flake8 errors to resolve conflicts with Black**
- **ci(backend): remove Python version matrix and Tox, add pre-commit action fix(settings): remove default value for EMAIL_PORT environment variable The CI workflow for the backend now uses a fixed Python version (3.12) instead of a matrix, simplifying the setup. Tox has been replaced by a direct `pre-commit` action, which ensures that pre-commit hooks are run on all files during CI, providing more robust validation. The default value for `EMAIL_PORT` in settings has been removed, making it mandatory to provide this value via an environment variable, which is a more secure and explicit configuration practice.**
- **ci(workflow): Downgrade pre-commit action version**
- **ci: provide dummy .env for pre-commit checks**
- **fix(job/tests): remove unused variable declaration in chat history test**
- **refactor: reformat long lines to adhere to E501 and improve readability docs(api): add OpenAPI schema for AdvancedSearchAPIView to improve API documentation fix(job): allow null client_id and client_name in JobSerializer for compatibility with old data**
- **refactor(accounts): Reorder staff list filters and log query parameters**
- **refactor: change several places of the code to fix regressions**
- **feat(job): add JobQuoteAcceptanceSerializer for quote acceptance response refactor(job): update JobQuoteAcceptRestView to use JobQuoteAcceptanceSerializer refactor(job): update AdvancedSearchAPIView to handle multiple status values feat(purchasing): introduce StockItemSerializer for individual stock items refactor(purchasing): update StockListSerializer to include total_count and use StockItemSerializer refactor(purchasing): modify PurchasingRestService.list_stock to return QuerySet refactor(purchasing): update StockListRestView to return paginated stock data refactor(purchasing): update StockConsumeRestView to return detailed consumption response refactor(workflow): update XeroQuoteManager to return xero_id on quote deletion docs(openapi): update schema for job quote acceptance and stock consumption endpoints docs(openapi): refine schema for advanced search status parameter**
- **chore: remove schema.yml file**
- **refactor(job): merge and simplify job event deduplication migration fix(job): remove conditional unique constraint for MariaDB compatibility refactor(job): remove duplicate event handling logic from job service**
- **refactor(accounts): add deprecation warning to get_is_active method**
- **fix(purchasing): allow negative stock quantities and remove buggy signal auto-connection**
- **refactor(timesheets): Improve API serialization, error‐handling & timesheet data flow**
- **chore: remove diff file**
- **refactor: improve costing serializer validation and clean up comments**
- **fix(costing_serializer): add missing exception raise to save method in CostLineCreateUpdateSerializer**
- **feat(docs): Document KPI calendar API and configure schema**
- **refactor(serializers): Change job_number fields to IntegerField**
- **fix(timesheet-api): Return wage rate as Decimal instead of string**
- **feat(api): enhance OpenAPI schema for purchasing endpoints**
