### PR TITLE
Fix/logout

### DIFF
--- a/apps/accounts/views/user_profile_view.py
+++ b/apps/accounts/views/user_profile_view.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from django.conf import settings
 from drf_spectacular.utils import OpenApiTypes, extend_schema
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -47,7 +47,7 @@ class LogoutUserAPIView(APIView):
     Custom logout view that clears JWT httpOnly cookies
     """
 
-    permission_classes = []  # No authentication required for logout
+    permission_classes = [AllowAny]
 
     @extend_schema(
         summary="Logs out the current user by clearing JWT cookies",

--- a/apps/job/views/month_end_rest_view.py
+++ b/apps/job/views/month_end_rest_view.py
@@ -3,6 +3,7 @@ import logging
 
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -38,46 +39,57 @@ class MonthEndRestView(APIView):
         return MonthEndGetResponseSerializer
 
     def get(self, request):
-        jobs = MonthEndService.get_special_jobs_data()
-        stock = MonthEndService.get_stock_job_data()
-        serialized_jobs = [
-            {
-                "job_id": str(item["job"].id),
-                "job_number": item["job"].job_number,
-                "job_name": item["job"].name,
-                "client_name": item["job"].client.name if item["job"].client else "",
+        try:
+            jobs = MonthEndService.get_special_jobs_data()
+            stock = MonthEndService.get_stock_job_data()
+            serialized_jobs = [
+                {
+                    "job_id": str(item["job"].id),
+                    "job_number": item["job"].job_number,
+                    "job_name": item["job"].name,
+                    "client_name": item["job"].client.name
+                    if item["job"].client
+                    else "",
+                    "history": [
+                        {
+                            "date": h["date"].date(),
+                            "total_hours": float(h["total_hours"]),
+                            "total_dollars": float(h["total_dollars"]),
+                        }
+                        for h in item["history"]
+                    ],
+                    "total_hours": float(item["total_hours"]),
+                    "total_dollars": float(item["total_dollars"]),
+                }
+                for item in jobs
+            ]
+            stock_serialized = {
+                "job_id": str(stock["job"].id),
+                "job_number": stock["job"].job_number,
+                "job_name": stock["job"].name,
                 "history": [
                     {
-                        "date": h["date"],
-                        "total_hours": float(h["total_hours"]),
-                        "total_dollars": float(h["total_dollars"]),
+                        "date": h["date"].date(),
+                        "material_line_count": h["material_line_count"],
+                        "material_cost": float(h["material_cost"]),
                     }
-                    for h in item["history"]
+                    for h in stock["history"]
                 ],
-                "total_hours": float(item["total_hours"]),
-                "total_dollars": float(item["total_dollars"]),
             }
-            for item in jobs
-        ]
-        stock_serialized = {
-            "job_id": str(stock["job"].id),
-            "job_number": stock["job"].job_number,
-            "job_name": stock["job"].name,
-            "history": [
-                {
-                    "date": h["date"],
-                    "material_line_count": h["material_line_count"],
-                    "material_cost": float(h["material_cost"]),
-                }
-                for h in stock["history"]
-            ],
-        }
 
-        response_data = {"jobs": serialized_jobs, "stock_job": stock_serialized}
-        response_serializer = MonthEndGetResponseSerializer(data=response_data)
-        response_serializer.is_valid(raise_exception=True)
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
+            response_data = {"jobs": serialized_jobs, "stock_job": stock_serialized}
+            response_serializer = MonthEndGetResponseSerializer(data=response_data)
+            response_serializer.is_valid(raise_exception=True)
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
+        except Exception as e:
+            logger.info(f"Error trying to get month-end information: {e}")
+            return Response({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    @extend_schema(
+        summary="Runs month-end operation based on given processed ids",
+        request=MonthEndPostRequestSerializer,
+        responses={200: MonthEndPostResponseSerializer},
+    )
     def post(self, request):
         try:
             # Validate input data

--- a/jobs_manager/authentication.py
+++ b/jobs_manager/authentication.py
@@ -59,7 +59,7 @@ class JWTAuthentication(BaseJWTAuthentication):
                 )
                 return None
             user, token = result
-            if not user.is_active:
+            if not user.is_currently_active:
                 raise exceptions.AuthenticationFailed(
                     "User is inactive.", code="user_inactive"
                 )

--- a/jobs_manager/settings.py
+++ b/jobs_manager/settings.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
+from rest_framework.permissions import IsAuthenticated
 
 # Import scopes from constants to ensure consistency
 from apps.workflow.api.xero.constants import XERO_SCOPES as DEFAULT_XERO_SCOPES_LIST
@@ -128,7 +129,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "apps.workflow.middleware.FrontendRedirectMiddleware",  # DEVE vir ANTES do AccessLogging
+    "apps.workflow.middleware.FrontendRedirectMiddleware",
     "apps.workflow.middleware.AccessLoggingMiddleware",
     "apps.workflow.middleware.LoginRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -267,7 +268,9 @@ SIMPLE_JWT = {
 
 # Disable DRF authentication entirely when DEBUG=True for local development
 if DEBUG:
-    from rest_framework.permissions import IsAuthenticated
+    REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = [
+        "rest_framework.permissions.AllowAny",
+    ]
 
     IsAuthenticated.has_permission = lambda self, request, view: True
     IsAuthenticated.has_object_permission = lambda self, request, view, obj: True


### PR DESCRIPTION
feat(month-end): Enhance API documentation and improve GET endpoint robustness
91ce278d refactor(settings): Use AllowAny for DRF default permissions in debug mode

e72f30e3 refactor(accounts): Use AllowAny permission for logout view

Summary of Changes
This PR primarily focuses on enhancing the API documentation and improving the robustness of the GET endpoint.

In addition to the main feature, the developer also made two key refactoring changes related to permissions:

General Permissions: The default Django Rest Framework (DRF) permission was changed to AllowAny when the application is in debug mode. This simplifies the development process by removing the need for authentication during local testing.

Logout Permissions: The permission for the logout view was also updated to AllowAny, ensuring users can log out without any authentication restrictions.