### PR TITLE
fix: use correct method name get_project_users instead of get_users

### DIFF
--- a/apps/workflow/management/commands/interact_with_xero.py
+++ b/apps/workflow/management/commands/interact_with_xero.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
 
         try:
             project_api = ProjectApi(api_client)
-            users = project_api.get_users(xero_tenant_id=tenant_id)
+            users = project_api.get_project_users(xero_tenant_id=tenant_id)
 
             self.stdout.write("Xero Users (Projects API):")
             self.stdout.write("---------------------------")


### PR DESCRIPTION
The ProjectApi has get_project_users method, not get_users.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
