### PR TITLE
fix: access users via ProjectUsers.items property

### DIFF
--- a/apps/workflow/management/commands/interact_with_xero.py
+++ b/apps/workflow/management/commands/interact_with_xero.py
@@ -109,12 +109,12 @@ class Command(BaseCommand):
 
         try:
             project_api = ProjectApi(api_client)
-            users = project_api.get_project_users(xero_tenant_id=tenant_id)
+            users_response = project_api.get_project_users(xero_tenant_id=tenant_id)
 
             self.stdout.write("Xero Users (Projects API):")
             self.stdout.write("---------------------------")
 
-            for user in users:
+            for user in users_response.items:
                 self.stdout.write(f"User ID: {user.user_id}")
                 self.stdout.write(f"Name: {user.name}")
                 self.stdout.write(f"Email: {user.email}")


### PR DESCRIPTION
The get_project_users method returns a ProjectUsers object with an items attribute containing the actual user list.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
