### PR TITLE
Fix poetry PATH issue in CI/CD deployments

### DIFF
--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -89,6 +89,7 @@ install_dependencies() {
     log "Installing dependencies..."
 
     cd "$PROJECT_PATH"
+    source ~/.bashrc
     source .venv/bin/activate
 
     # Python dependencies


### PR DESCRIPTION
## Summary
- Fixed deploy_machine.sh to source ~/.bashrc before using poetry
- This ensures poetry is available in PATH when running via SSH/CI/CD
- Cleaned up completed UAT deployment improvement plan

## Test plan
- [x] CI tests pass
- [ ] Deploy to scheduler succeeds with poetry available
- [ ] Verify poetry install works in automated deployment

🤖 Generated with [Claude Code](https://claude.ai/code)