### PR TITLE
fix: explicitly export PATH for poetry in deployment script

### DIFF
--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -89,7 +89,11 @@ install_dependencies() {
     log "Installing dependencies..."
 
     cd "$PROJECT_PATH"
+
+    # Ensure poetry is in PATH
+
     source ~/.bashrc
+    export PATH="$HOME/.local/bin:$PATH"
     source .venv/bin/activate
 
     # Python dependencies


### PR DESCRIPTION
Add explicit PATH export to ensure poetry is available when running via SSH/CI. Keeps both ~/.bashrc source and PATH export for reliability.

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
