### PR TITLE
fix: use bash -lc for SSH deployment to load user environment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
             echo "Deploying to Scheduler Machine: $SCHEDULER_HOST"
 
-            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$SCHEDULER_HOST "$PROJECT_PATH/scripts/deploy_machine.sh main scheduler"; then
+            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$SCHEDULER_HOST "bash -lc '$PROJECT_PATH/scripts/deploy_machine.sh main scheduler'"; then
               echo "Scheduler machine deployment successful"
             else
               echo "Scheduler machine deployment failed"
@@ -52,7 +52,7 @@ jobs:
         run: |
             echo "Deploying to Frontend/Backend Machine: $FRONTEND_HOST"
 
-            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$FRONTEND_HOST "$PROJECT_PATH/scripts/deploy_machine.sh main frontend"; then
+            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$FRONTEND_HOST "bash -lc '$PROJECT_PATH/scripts/deploy_machine.sh main frontend'"; then
               echo "Frontend/Backend machine deployment successful"
             else
               echo "Frontend/Backend machine deployment failed or machine offline"

--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -89,11 +89,6 @@ install_dependencies() {
     log "Installing dependencies..."
 
     cd "$PROJECT_PATH"
-
-    # Ensure poetry is in PATH
-
-    source ~/.bashrc
-    export PATH="$HOME/.local/bin:$PATH"
     source .venv/bin/activate
 
     # Python dependencies


### PR DESCRIPTION
ChatGPT suggested using login shell (-lc) to properly load user's ~/.bashrc and PATH settings, which should make poetry available without manual PATH exports.

Simplified deploy_machine.sh by removing manual PATH manipulation since login shell handles it properly.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
