### PR TITLE
feat(job): add pricing methodology field to job creation

### DIFF
--- a/apps/job/serializers/job_serializer.py
+++ b/apps/job/serializers/job_serializer.py
@@ -389,6 +389,9 @@ class JobCreateRequestSerializer(serializers.Serializer):
     order_number = serializers.CharField(required=False, allow_blank=True)
     notes = serializers.CharField(required=False, allow_blank=True)
     contact_id = serializers.UUIDField(required=False, allow_null=True)
+    pricing_methodology = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True
+    )
 
 
 class JobCreateResponseSerializer(serializers.Serializer):

--- a/apps/job/services/job_rest_service.py
+++ b/apps/job/services/job_rest_service.py
@@ -71,7 +71,12 @@ class JobRestService:
         }
 
         # Optional fields - only if provided
-        optional_fields = ["description", "order_number", "notes"]
+        optional_fields = [
+            "description",
+            "order_number",
+            "notes",
+            "pricing_methodology",
+        ]
         for field in optional_fields:
             if data.get(field):
                 job_data[field] = data[field]

--- a/apps/job/views/job_rest_views.py
+++ b/apps/job/views/job_rest_views.py
@@ -177,6 +177,7 @@ class JobCreateRestView(BaseJobRestView):
             "order_number": "Optional order number",
             "notes": "Optional notes",
             "contact_id": "optional-contact-uuid"
+            "pricing_methodology": "Optional methodology (defaults to T&M)"
         }
         """
         try:


### PR DESCRIPTION
Adds a new `pricing_methodology` field to the job creation process. This field is optional and allows specifying the pricing methodology for a job. It is included in the `JobCreateRequestSerializer`, processed by `JobRestService`, and documented in the `JobCreateRestView` example.