### PR TITLE
feat(ci/cd): migrate from SSH to AWS SSM for deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,48 +15,138 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # SSH Configuration and EC2 Deploy
-      - name: Set up SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+      # AWS Configuration
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Debug All Variables
         run: |
-          echo "SCHEDULER_HOST: ${{ vars.SCHEDULER_HOST }}"
-          echo "FRONTEND_HOST: ${{ vars.FRONTEND_HOST }}"
-          echo "AWS_USER: ${{ vars.AWS_USER }}"
+          echo "SCHEDULER_INSTANCE_ID: ${{ vars.SCHEDULER_INSTANCE_ID }}"
+          echo "FRONTEND_INSTANCE_ID: ${{ vars.FRONTEND_INSTANCE_ID }}"
+          echo "AWS_REGION: ${{ vars.AWS_REGION }}"
           echo "PROJECT_PATH: ${{ vars.PROJECT_PATH }}"
 
       - name: Deploy to Scheduler Machine
         env:
-            SCHEDULER_HOST: ${{ vars.SCHEDULER_HOST }}
-            AWS_USER: ${{ vars.AWS_USER }}
+            SCHEDULER_INSTANCE_ID: ${{ vars.SCHEDULER_INSTANCE_ID }}
             PROJECT_PATH: ${{ vars.PROJECT_PATH }}
+            AWS_REGION: ${{ vars.AWS_REGION }}
         run: |
-            echo "Deploying to Scheduler Machine: $SCHEDULER_HOST"
+            echo "Deploying to Scheduler Machine: $SCHEDULER_INSTANCE_ID"
 
-            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$SCHEDULER_HOST "bash -lc '$PROJECT_PATH/scripts/deploy_machine.sh main scheduler'"; then
-              echo "Scheduler machine deployment successful"
-            else
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids $SCHEDULER_INSTANCE_ID \
+              --document-name "AWS-RunShellScript" \
+              --parameters "commands=['sudo su - ubuntu -c \"$PROJECT_PATH/scripts/deploy_machine.sh main scheduler\"']" \
+              --region $AWS_REGION \
+              --query 'Command.CommandId' \
+              --output text)
+
+            echo "Command ID: $COMMAND_ID"
+
+            # Wait for command to complete
+            aws ssm wait command-executed \
+              --command-id $COMMAND_ID \
+              --instance-id $SCHEDULER_INSTANCE_ID \
+              --region $AWS_REGION
+
+            # Get command output
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $SCHEDULER_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'Status' \
+              --output text)
+
+            OUTPUT=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $SCHEDULER_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'StandardOutputContent' \
+              --output text)
+
+            ERROR_OUTPUT=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $SCHEDULER_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'StandardErrorContent' \
+              --output text)
+
+            echo "Status: $STATUS"
+            echo "Output: $OUTPUT"
+            if [ "$ERROR_OUTPUT" != "None" ] && [ "$ERROR_OUTPUT" != "" ]; then
+              echo "Error Output: $ERROR_OUTPUT"
+            fi
+
+            if [ "$STATUS" != "Success" ]; then
               echo "Scheduler machine deployment failed"
               exit 1
+            else
+              echo "Scheduler machine deployment successful"
             fi
 
       - name: Deploy to Frontend/Backend Machine
         continue-on-error: true
         env:
-            FRONTEND_HOST: ${{ vars.FRONTEND_HOST }}
-            AWS_USER: ${{ vars.AWS_USER }}
+            FRONTEND_INSTANCE_ID: ${{ vars.FRONTEND_INSTANCE_ID }}
             PROJECT_PATH: ${{ vars.PROJECT_PATH }}
+            AWS_REGION: ${{ vars.AWS_REGION }}
         run: |
-            echo "Deploying to Frontend/Backend Machine: $FRONTEND_HOST"
+            echo "Deploying to Frontend/Backend Machine: $FRONTEND_INSTANCE_ID"
 
-            if ssh -T -o StrictHostKeyChecking=no -o ConnectTimeout=10 $AWS_USER@$FRONTEND_HOST "bash -lc '$PROJECT_PATH/scripts/deploy_machine.sh main frontend'"; then
-              echo "Frontend/Backend machine deployment successful"
-            else
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids $FRONTEND_INSTANCE_ID \
+              --document-name "AWS-RunShellScript" \
+              --parameters "commands=['sudo su - ubuntu -c \"$PROJECT_PATH/scripts/deploy_machine.sh main frontend\"']" \
+              --region $AWS_REGION \
+              --query 'Command.CommandId' \
+              --output text)
+
+            echo "Command ID: $COMMAND_ID"
+
+            # Wait for command to complete
+            aws ssm wait command-executed \
+              --command-id $COMMAND_ID \
+              --instance-id $FRONTEND_INSTANCE_ID \
+              --region $AWS_REGION
+
+            # Get command output
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $FRONTEND_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'Status' \
+              --output text)
+
+            OUTPUT=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $FRONTEND_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'StandardOutputContent' \
+              --output text)
+
+            ERROR_OUTPUT=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $FRONTEND_INSTANCE_ID \
+              --region $AWS_REGION \
+              --query 'StandardErrorContent' \
+              --output text)
+
+            echo "Status: $STATUS"
+            echo "Output: $OUTPUT"
+            if [ "$ERROR_OUTPUT" != "None" ] && [ "$ERROR_OUTPUT" != "" ]; then
+              echo "Error Output: $ERROR_OUTPUT"
+            fi
+
+            if [ "$STATUS" != "Success" ]; then
               echo "Frontend/Backend machine deployment failed or machine offline"
               exit 1
+            else
+              echo "Frontend/Backend machine deployment successful"
             fi
 
       - name: Deployment Summary


### PR DESCRIPTION
Replaces SSH-based deployment with AWS Systems Manager for improved security and reliability:
- Use AWS SSM send-command instead of direct SSH connections
- Add proper AWS credentials configuration
- Replace host variables with instance IDs
- Add comprehensive command status checking and output capture
- Maintain existing deployment logic with improved error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
