### PR TITLE
feat(timesheet): add weekend timesheet functionality with feature flag

### DIFF
--- a/.kilocode/tasks/weekend_timesheet_architecture.md
+++ b/.kilocode/tasks/weekend_timesheet_architecture.md
@@ -1,0 +1,331 @@
+# Weekend Timesheet Inclusion - Architecture Overview
+
+## System Architecture
+
+### Current Architecture
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Frontend      │    │   API Layer      │    │  Service Layer  │
+│   (Vue.js)      │◄──►│   (Django REST)  │◄──►│   (Business     │
+│                 │    │                  │    │    Logic)       │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Database      │    │   Serializers    │    │   Models        │
+│   (MariaDB)     │    │   (DRF)          │    │   (Django)      │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+```
+
+### Weekend Inclusion Architecture
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Frontend      │    │   API Layer      │    │  Service Layer  │
+│   (7-day grid)  │◄──►│   (7-day data)   │◄──►│   (7-day logic) │
+│                 │    │                  │    │                 │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Database      │    │   Serializers    │    │   Models        │
+│   (Weekend OK)  │    │   (7-day compat) │    │   (UUID dates)  │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+```
+
+## Component Analysis
+
+### 1. Service Layer (`WeeklyTimesheetService`)
+
+#### Current Implementation
+```python
+class WeeklyTimesheetService:
+    @classmethod
+    def _get_week_days(cls, start_date, export_to_ims=False):
+        if export_to_ims:
+            return cls._get_ims_week(start_date)  # Tue-Fri + next Mon
+        else:
+            return [start_date + timedelta(days=i) for i in range(5)]  # Mon-Fri
+```
+
+#### Updated Implementation
+```python
+class WeeklyTimesheetService:
+    @classmethod
+    def _get_week_days(cls, start_date, export_to_ims=False):
+        if export_to_ims:
+            return cls._get_ims_week(start_date)  # Mon-Fri (simplified)
+        else:
+            return [start_date + timedelta(days=i) for i in range(7)]  # Mon-Sun
+```
+
+#### Key Changes
+- **Standard mode**: Returns 7 days instead of 5
+- **IMS mode**: Changed to Monday-Friday (simplified from Tue-Fri + next Mon)
+- **Leave processing**: Removed weekend skip logic
+
+### 2. API Layer (`TimesheetResponseMixin`)
+
+#### Current Flow
+```
+Request → build_timesheet_response() → WeeklyTimesheetService.get_weekly_overview()
+    ↓
+Service returns 5-day data → Serializer → Response
+```
+
+#### Updated Flow
+```
+Request → build_timesheet_response() → WeeklyTimesheetService.get_weekly_overview()
+    ↓
+Service returns 7-day data → Serializer → Response
+```
+
+#### Key Changes
+- No changes needed - automatically handles 7-day data from service
+- Serializers must support variable-length day arrays
+- Response structure remains compatible
+
+### 3. View Layer (`ModernTimesheetEntryView`, `ModernTimesheetDayView`)
+
+#### Current Implementation
+```python
+# Individual entries - already weekend-compatible
+def get(self, request):
+    # Accepts any date parameter
+    entry_date = request.query_params.get("date")
+    # No weekday validation
+
+def post(self, request):
+    # Creates entries for any date
+    entry_date = validated_data["date"]
+    # No weekend restrictions
+```
+
+#### Key Changes
+- **No changes required** - views already accept any date
+- **Validation**: Ensure no hidden weekday checks
+- **Queries**: Confirm date filtering works for weekends
+
+### 4. Data Layer (CostLine Model)
+
+#### Current Schema
+```python
+class CostLine(models.Model):
+    meta = models.JSONField()  # Contains date, staff_id, etc.
+    # Date stored as: {"date": "2024-01-13", ...}
+```
+
+#### Weekend Compatibility
+- ✅ **Database**: No constraints on weekend dates
+- ✅ **JSON queries**: MariaDB JSON_EXTRACT works with any date
+- ✅ **Storage**: Weekend dates store normally
+- ✅ **Retrieval**: Queries work for any date
+
+## Data Flow Architecture
+
+### Standard Weekly Overview (7 days)
+```
+1. API Request: GET /api/weekly/?start_date=2024-01-15
+2. TimesheetResponseMixin.build_timesheet_response()
+3. WeeklyTimesheetService.get_weekly_overview(start_date)
+4. _get_week_days() → [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
+5. _get_staff_data(week_days) → Process all 7 days
+6. Return 7-day data structure
+7. Serializer formats response
+8. Frontend receives 7 columns
+```
+
+### IMS Export (Special format)
+```
+1. API Request: GET /api/weekly/ims/?start_date=2024-01-15
+2. TimesheetResponseMixin.build_timesheet_response(export_to_ims=True)
+3. WeeklyTimesheetService.get_weekly_overview(start_date, export_to_ims=True)
+4. _get_ims_week() → [Mon, Tue, Wed, Thu, Fri]
+5. _get_staff_data(week_days, export_to_ims=True) → IMS processing
+6. Return IMS-formatted data
+7. Serializer formats IMS response
+8. Export uses Monday-Friday format (simplified)
+```
+
+### Individual Day Entry
+```
+1. API Request: POST /api/entries/ with weekend date
+2. ModernTimesheetEntryView.post()
+3. Validate date (no weekend restrictions)
+4. Create CostLine with weekend date in meta
+5. Return success response
+```
+
+## Integration Points
+
+### Frontend Integration
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Frontend Grid Component                                    │
+├─────────────────────────────────────────────────────────────┤
+│ Headers: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]              │
+│ Data:   [data, data, data, data, data, data, data]         │
+│ Totals:  [sum, sum, sum, sum, sum, sum, sum]               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Database Integration
+```
+CostLine.meta JSON structure:
+{
+  "staff_id": "uuid",
+  "date": "2024-01-13",  // Weekend dates OK
+  "is_billable": true,
+  "wage_rate": 25.0,
+  "created_from_timesheet": true
+}
+```
+
+### Export Integration
+```
+IMS Export: Monday-Friday (simplified)
+Standard Export: Mon-Sun (new capability)
+Xero Integration: Includes weekend dates
+```
+
+## Validation Architecture
+
+### Input Validation
+```python
+# Before: Weekend blocking
+if date.weekday() >= 5:
+    raise ValidationError("Weekends not allowed")
+
+# After: Weekend allowed
+# No weekday validation
+```
+
+### Business Rule Validation
+```python
+# Weekend warnings (optional)
+if date.weekday() >= 5:
+    logger.warning(f"Weekend work on {date}")
+
+# But allow the entry
+```
+
+## Performance Considerations
+
+### Query Optimization
+- **JSON field queries**: Use database indexes on JSON fields
+- **Date range queries**: Ensure proper indexing on date fields
+- **Batch processing**: Handle 7-day data efficiently
+
+### Memory Management
+- **Response size**: 7-day data is ~40% larger than 5-day
+- **Caching**: Update cache keys to include weekend data
+- **Pagination**: Consider pagination for large datasets
+
+## Testing Architecture
+
+### Unit Tests
+```python
+def test_weekly_overview_includes_weekends(self):
+    # Test 7-day data structure
+    overview = WeeklyTimesheetService.get_weekly_overview(start_date)
+    self.assertEqual(len(overview['week_days']), 7)
+    self.assertEqual(len(overview['staff_data'][0]['weekly_hours']), 7)
+```
+
+### Integration Tests
+```python
+def test_end_to_end_weekend_entry(self):
+    # Create weekend entry
+    response = self.client.post('/api/entries/', weekend_data)
+    self.assertEqual(response.status_code, 201)
+
+    # Verify in weekly overview
+    overview = self.client.get('/api/weekly/')
+    weekend_data = overview.data['staff_data'][0]['weekly_hours'][5]  # Saturday
+    self.assertIsNotNone(weekend_data['hours'])
+```
+
+## Deployment Strategy
+
+### Phased Rollout
+1. **Phase 1**: Backend changes (service layer)
+2. **Phase 2**: API updates (response builders)
+3. **Phase 3**: Frontend updates (7-column grids)
+4. **Phase 4**: Testing and validation
+
+### Feature Flags
+```python
+# Mandatory: Feature flag for weekend functionality
+WEEKEND_TIMESHEETS_ENABLED = os.getenv('WEEKEND_TIMESHEETS_ENABLED', 'false')
+
+if WEEKEND_TIMESHEETS_ENABLED == 'true':
+    # Weekend mode enabled
+    week_days = [start_date + timedelta(days=i) for i in range(7)]  # Mon-Sun
+    ims_week = [start_date + timedelta(days=i) for i in range(5)]   # Mon-Fri
+    skip_weekends = False
+else:
+    # Legacy mode (default)
+    week_days = [start_date + timedelta(days=i) for i in range(5)]  # Mon-Fri
+    ims_week = cls._get_ims_week_legacy(start_date)                # Tue-Fri + next Mon
+    skip_weekends = True
+```
+
+### Feature Flag Integration
+```python
+class WeeklyTimesheetService:
+    @classmethod
+    def _get_week_days(cls, start_date, export_to_ims=False):
+        """Get list of days for the week based on feature flag."""
+        weekend_enabled = os.getenv('WEEKEND_TIMESHEETS_ENABLED', 'false') == 'true'
+
+        if export_to_ims:
+            if weekend_enabled:
+                return cls._get_ims_week_simple(start_date)  # Mon-Fri
+            else:
+                return cls._get_ims_week_legacy(start_date)  # Tue-Fri + next Mon
+        else:
+            if weekend_enabled:
+                return [start_date + timedelta(days=i) for i in range(7)]  # Mon-Sun
+            else:
+                return [start_date + timedelta(days=i) for i in range(5)]  # Mon-Fri
+```
+
+## Monitoring and Observability
+
+### Key Metrics
+- **Response times**: Monitor API performance with 7-day data
+- **Error rates**: Track weekend-specific errors
+- **Data completeness**: Ensure weekend entries are processed
+- **User adoption**: Track weekend entry creation
+
+### Logging
+```python
+logger.info(f"Processing {len(week_days)}-day timesheet for {start_date}")
+logger.info(f"Weekend entries found: {weekend_count}")
+```
+
+## Security Considerations
+
+### Data Access
+- **Authorization**: Same permissions apply to weekend data
+- **Audit trails**: Weekend entries logged normally
+- **Data integrity**: Weekend dates validated like weekdays
+
+### Input Validation
+- **Date format**: Weekend dates use same validation
+- **Business rules**: Weekend entries subject to same rules
+- **Rate limiting**: Same limits apply
+
+## Future Extensions
+
+### Weekend-Specific Features
+- **Weekend rates**: Different rates for weekend work
+- **Overtime rules**: Weekend overtime calculations
+- **Scheduling**: Weekend shift planning
+- **Reporting**: Weekend-specific analytics
+
+### Advanced Analytics
+- **Weekend patterns**: Analyze weekend work trends
+- **Productivity metrics**: Compare weekday vs weekend productivity
+- **Cost analysis**: Weekend labor cost tracking
+
+This architecture ensures seamless weekend inclusion while maintaining backward compatibility and system performance.

--- a/.kilocode/tasks/weekend_timesheet_requirements.md
+++ b/.kilocode/tasks/weekend_timesheet_requirements.md
@@ -1,0 +1,361 @@
+# Weekend Timesheet Inclusion - Requirements
+
+## Overview
+The timesheet system currently excludes weekends from data fetching and processing. This needs to be updated to include Saturday and Sunday in all timesheet operations while maintaining existing functionality.
+
+## Current State Analysis
+- ✅ **Fixed**: WeeklyTimesheetService._get_week_days() now returns 7 days (Mon-Sun)
+- ✅ **Fixed**: Paid leave auto-creation no longer skips weekends
+- ✅ **Fixed**: API documentation updated to reflect Mon-Sun coverage
+- ❌ **Missing**: Response builders may still slice to 5 days
+- ❌ **Missing**: Serializers may expect fixed 5-day structures
+- ❌ **Missing**: Frontend may have hardcoded 5-column grids
+- ❌ **Missing**: Export services may filter weekends
+- ❌ **Missing**: Tests expect 5-day structures
+
+## Requirements
+
+### Functional Requirements
+
+#### 1. Data Processing
+- **REQ-001**: All timesheet queries must include weekend dates
+- **REQ-002**: Weekly overviews must display 7 days (Mon-Sun)
+- **REQ-003**: Daily summaries must work for any day of the week
+- **REQ-004**: Leave submissions must allow weekend dates
+- **REQ-005**: Time entry creation must accept weekend dates
+
+#### 2. API Endpoints
+- **REQ-006**: WeeklyTimesheetAPIView must return 7-day data structures
+- **REQ-007**: DailyTimesheetAPIView must handle weekend dates
+- **REQ-008**: ModernTimesheetEntryView must accept weekend entries
+- **REQ-009**: All date-based queries must include weekends
+
+#### 3. Business Logic
+- **REQ-010**: Scheduled hours calculation must work for weekends
+- **REQ-011**: Overtime calculations must consider weekend work
+- **REQ-012**: Leave processing must include weekends
+- **REQ-013**: Status calculations must account for 7-day weeks
+
+#### 4. Data Integrity
+- **REQ-014**: No data loss when expanding to 7 days
+- **REQ-015**: Backward compatibility maintained
+- **REQ-016**: Existing weekend data must be preserved
+
+### Non-Functional Requirements
+
+#### 5. Performance
+- **REQ-017**: Query performance must not degrade with weekend inclusion
+- **REQ-018**: Response times must remain acceptable
+- **REQ-019**: Memory usage must be optimized for 7-day structures
+
+#### 6. Compatibility
+- **REQ-020**: IMS export format must remain unchanged (Tue-Fri + next Mon)
+- **REQ-021**: Existing API contracts must be maintained
+- **REQ-022**: Frontend integration must be seamless
+
+#### 7. Validation
+- **REQ-023**: Manual validation must verify weekend functionality
+- **REQ-024**: Code review must ensure quality and consistency
+- **REQ-025**: Manual testing must cover weekend scenarios
+
+## Constraints and Assumptions
+
+### Technical Constraints
+- Database schema supports weekend dates (no constraints)
+- JSON field queries work for weekend dates
+- CostLine model can store weekend entries
+- Existing date parsing handles weekend dates
+
+### Business Constraints
+- IMS export format must remain Tue-Fri + next Mon
+- Some business rules may discourage weekend work (warnings, not blocks)
+- Leave policies may apply to weekends
+- Overtime rules may differ for weekends
+
+### Assumptions
+- Frontend can be updated to handle 7-column grids
+- Users want weekend timesheet capability
+- No additional database migrations needed
+- Existing weekend data exists and should be preserved
+
+## Feature Flag Implementation
+
+### Mandatory Feature Flag Rules
+- **WEEKEND_TIMESHEETS_ENABLED**: Environment variable to control weekend functionality
+- **Default Value**: `false` (maintains backward compatibility)
+- **Type**: Boolean
+- **Scope**: Global application setting
+
+### Feature Flag Behavior
+- **When `false` (default)**:
+  - Standard mode: Monday-Friday (5 days)
+  - IMS mode: Monday-Friday (simplified)
+  - Leave processing: Skip weekends
+  - All validations remain weekday-only
+
+- **When `true`**:
+  - Standard mode: Monday-Sunday (7 days)
+  - IMS mode: Monday-Friday (simplified)
+  - Leave processing: Include all days
+  - Weekend entries allowed
+
+### Implementation Requirements
+- **REQ-026**: Feature flag must be checked in all relevant service methods
+- **REQ-027**: Feature flag must be configurable via CompanyDefauls model:
+
+```py
+from django.core.exceptions import ValidationError
+from django.db import models, transaction
+
+
+class CompanyDefaults(models.Model):
+    company_name = models.CharField(max_length=255, primary_key=True)
+    is_primary = models.BooleanField(default=True, unique=True)
+    time_markup = models.DecimalField(max_digits=5, decimal_places=2, default=0.3)
+    materials_markup = models.DecimalField(max_digits=5, decimal_places=2, default=0.2)
+    charge_out_rate = models.DecimalField(
+        max_digits=6, decimal_places=2, default=105.00
+    )  # rate per hour
+    wage_rate = models.DecimalField(
+        max_digits=6, decimal_places=2, default=32.00
+    )  # rate per hour
+
+    starting_job_number = models.IntegerField(
+        default=1,
+        help_text="Helper field to set the starting job number based on the latest paper job",
+    )
+    starting_po_number = models.IntegerField(
+        default=1, help_text="Helper field to set the starting purchase order number"
+    )
+    po_prefix = models.CharField(
+        max_length=10,
+        default="PO-",
+        help_text="Prefix for purchase order numbers (e.g., PO-, JO-)",
+    )
+
+    # Google Sheets integration for Job Quotes
+    master_quote_template_url = models.URLField(
+        null=True,
+        blank=True,
+        help_text="URL to the master Google Sheets quote template",
+    )
+
+    master_quote_template_id = models.CharField(
+        null=True,
+        blank=True,
+        help_text="Google Sheets ID for the quote template",
+        max_length=100,
+    )
+
+    gdrive_quotes_folder_url = models.URLField(
+        null=True,
+        blank=True,
+        help_text="URL to the Google Drive folder for storing quotes",
+    )
+
+    gdrive_quotes_folder_id = models.CharField(
+        null=True,
+        blank=True,
+        help_text="Google Drive folder ID for storing quotes",
+        max_length=100,
+    )
+
+    # Xero integration
+    xero_tenant_id = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        help_text="The Xero tenant ID to use for this company",
+    )
+
+    # Default working hours (Mon-Fri, 7am - 3pm)
+    mon_start = models.TimeField(default="07:00")
+    mon_end = models.TimeField(default="15:00")
+    tue_start = models.TimeField(default="07:00")
+    tue_end = models.TimeField(default="15:00")
+    wed_start = models.TimeField(default="07:00")
+    wed_end = models.TimeField(default="15:00")
+    thu_start = models.TimeField(default="07:00")
+    thu_end = models.TimeField(default="15:00")
+    fri_start = models.TimeField(default="07:00")
+    fri_end = models.TimeField(default="15:00")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    last_xero_sync = models.DateTimeField(
+        null=True, blank=True, help_text="The last time Xero data was synchronized"
+    )
+    last_xero_deep_sync = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="The last time a deep Xero sync was performed (looking back 90 days)",
+    )
+
+    # Shop client configuration
+    shop_client_name = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Name of the internal shop client for tracking shop work (e.g., 'MSM (Shop)')",
+    )
+
+    # KPI thresholds
+    billable_threshold_green = models.DecimalField(
+        max_digits=5,
+        decimal_places=2,
+        default=45.0,
+        verbose_name="Green Threshold of Billable Hours",
+        help_text="Daily billable hours above this threshold are marked in green",
+    )
+    billable_threshold_amber = models.DecimalField(
+        max_digits=5,
+        decimal_places=2,
+        default=30.0,
+        verbose_name="Amber Threshold of Billable Hours",
+        help_text="Daily billable hours between this threshold and the green threshold are marked in amber",
+    )
+    daily_gp_target = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        default=1250.0,
+        verbose_name="Daily Goal of Gross Profit",
+        help_text="Daily gross profit goal in dolars",
+    )
+    shop_hours_target_percentage = models.DecimalField(
+        max_digits=5,
+        decimal_places=2,
+        default=20.0,
+        verbose_name="Hours percentage goal in Shop Jobs",
+        help_text="Target percentage of hours worked in shop jobs",
+    )
+
+    class Meta:
+        verbose_name = "Company Defaults"
+        verbose_name_plural = "Company Defaults"
+
+    def save(self, *args, **kwargs):
+        print(
+            f"DEBUG: CompanyDefaults.save called with shop_client_name = {self.shop_client_name}"
+        )
+        if not self.pk and CompanyDefaults.objects.exists():
+            raise ValidationError("There can be only one CompanyDefaults instance")
+        self.is_primary = True
+        print(
+            f"DEBUG: About to call super().save() with shop_client_name = {self.shop_client_name}"
+        )
+        result = super().save(*args, **kwargs)
+        print(
+            f"DEBUG: After super().save(), shop_client_name = {self.shop_client_name}"
+        )
+        return result
+
+    @classmethod
+    def get_instance(cls) -> "CompanyDefaults":
+        """
+        Get the singleton instance.
+        This is the preferred way to get the CompanyDefaults instance.
+        """
+        with transaction.atomic():
+            return cls.objects.get()
+
+    @property
+    def llm_api_key(self):
+        """
+        Returns the API key of the active LLM provider.
+        """
+        from .ai_provider import AIProvider
+
+        active_provider = AIProvider.objects.filter(default=True).first()
+        return active_provider.api_key if active_provider else None
+
+    def __str__(self):
+        return self.company_name
+
+```
+
+- **REQ-028**: Feature flag must support runtime changes without restart
+- **REQ-029**: Feature flag must be documented in deployment guides
+- **REQ-030**: Feature flag must include migration path for existing data
+
+## Success Criteria
+
+### Functional Success
+- [ ] Weekly overviews show 7 days of data
+- [ ] Weekend dates can be queried individually
+- [ ] Leave can be submitted for weekends
+- [ ] Time entries can be created for weekends
+- [ ] All calculations work with 7-day data
+
+### Technical Success
+- [ ] No breaking changes to existing APIs
+- [ ] Performance remains acceptable
+- [ ] Feature flag works correctly
+- [ ] Manual validation passes
+
+### Business Success
+- [ ] Users can track weekend work
+- [ ] Reporting includes weekend data
+- [ ] Export functionality works correctly
+- [ ] Data integrity preserved
+
+## Risk Assessment
+
+### High Risk
+- **RISK-001**: Frontend grid components may break with 7 columns
+- **RISK-002**: Performance degradation with larger datasets
+- **RISK-003**: Feature flag configuration errors
+
+### Medium Risk
+- **RISK-004**: Business logic errors in weekend calculations
+- **RISK-005**: Export format incompatibilities
+- **RISK-006**: Data consistency issues
+
+### Low Risk
+- **RISK-007**: API documentation inconsistencies
+- **RISK-008**: Minor UI adjustments needed
+
+## Dependencies
+
+### Internal Dependencies
+- CostLine model and related queries
+- WeeklyTimesheetService functionality
+- API endpoint implementations
+- Frontend grid components
+
+### External Dependencies
+- Database performance with larger result sets
+- Frontend framework compatibility
+- User acceptance of weekend functionality
+
+## Acceptance Criteria
+
+### Code Quality
+- [ ] All code follows existing patterns
+- [ ] No hardcoded weekday assumptions
+- [ ] Proper error handling for weekend dates
+- [ ] Comprehensive logging
+
+### Validation
+- [ ] Manual validation of weekend functionality
+- [ ] Code review for quality and consistency
+- [ ] Manual testing of weekend scenarios
+- [ ] Performance monitoring with 7-day data
+
+### Documentation
+- [ ] API documentation updated
+- [ ] Code comments reflect 7-day functionality
+- [ ] User documentation updated if needed
+
+## Out of Scope
+
+### Explicitly Excluded
+- Frontend UI redesign (beyond basic 7-column support)
+- Database schema changes
+- Business rule changes for weekend overtime
+- Mobile application updates
+- Third-party integration changes
+
+### Future Considerations
+- Weekend-specific business rules
+- Enhanced reporting for weekend work
+- Automated weekend scheduling
+- Advanced overtime calculations

--- a/.kilocode/tasks/weekend_timesheet_tasks.md
+++ b/.kilocode/tasks/weekend_timesheet_tasks.md
@@ -1,0 +1,244 @@
+# Weekend Timesheet Inclusion - Task Breakdown
+
+## Task Overview
+Complete the implementation of weekend inclusion in the timesheet system by addressing all remaining blockers and ensuring end-to-end functionality.
+
+## Task Categories
+
+### 1. Backend Service Layer (High Priority)
+
+#### TASK-001: Verify WeeklyTimesheetService Integration
+- **Description**: Ensure all service methods properly handle 7-day data structures
+- **Subtasks**:
+  - Verify `_get_week_days()` returns 7 days consistently
+  - Check `_get_staff_data()` processes all 7 days
+  - Validate `_calculate_weekly_totals()` works with 7-day data
+  - Test `_get_job_metrics()` includes weekend dates in queries
+- **Files**: `apps/timesheet/services/weekly_timesheet_service.py`
+- **Priority**: Critical
+
+#### TASK-002: Update Response Builders
+- **Description**: Ensure TimesheetResponseMixin.build_timesheet_response() handles 7-day data
+- **Subtasks**:
+  - Verify response includes all 7 days from service
+  - Check serializer compatibility with 7-day structures
+  - Validate navigation dates work correctly
+  - Test both standard and IMS export modes
+- **Files**: `apps/timesheet/views/api.py`
+- **Priority**: Critical
+
+### 2. View Layer Updates (High Priority)
+
+#### TASK-003: Modern Timesheet Views Audit
+- **Description**: Audit and update modern_timesheet_views.py for weekend compatibility
+- **Subtasks**:
+  - Check for hardcoded weekday assumptions
+  - Verify date parsing accepts weekend dates
+  - Ensure queries include weekend dates
+  - Test individual day views work for weekends
+- **Files**: `apps/job/views/modern_timesheet_views.py`
+- **Priority**: Critical
+
+#### TASK-004: Daily Timesheet Service Integration
+- **Description**: Ensure DailyTimesheetService works with weekend dates
+- **Subtasks**:
+  - Verify service methods handle weekend dates
+  - Check date range queries include weekends
+  - Test staff-specific daily views for weekends
+  - Validate summary calculations work for weekends
+- **Files**: `apps/timesheet/services/daily_timesheet_service.py`
+- **Priority**: High
+
+### 3. Validation and Constraints (Medium Priority)
+
+#### TASK-005: Remove Weekday-Only Validations
+- **Description**: Find and remove any validations that block weekend entries
+- **Subtasks**:
+  - Search for weekday/weekend validation logic
+  - Remove or relax weekend-blocking checks
+  - Keep business warnings for weekend work
+  - Update error messages to be inclusive
+- **Files**: All view and service files
+- **Priority**: High
+
+#### TASK-006: Business Logic Updates
+- **Description**: Update business logic to handle weekend scenarios
+- **Subtasks**:
+  - Verify scheduled hours work for weekends
+  - Check overtime calculations include weekends
+  - Test leave processing for weekend dates
+  - Validate status calculations with 7-day weeks
+- **Files**: Service layer files
+- **Priority**: Medium
+
+### 4. Export and Integration (Medium Priority)
+
+#### TASK-007: Export Services Audit
+- **Description**: Ensure export services include weekend data appropriately
+- **Subtasks**:
+  - Verify IMS export maintains Tue-Fri + next Mon format
+  - Check Xero integration includes weekend dates
+  - Test payroll exports work with weekend data
+  - Validate third-party integrations
+- **Files**: Export service files
+- **Priority**: Medium
+
+#### TASK-013: Feature Flag Implementation
+- **Description**: Implement feature flag for weekend functionality
+- **Subtasks**:
+  - Add WEEKEND_TIMESHEETS_ENABLED environment variable
+  - Update WeeklyTimesheetService to check feature flag
+  - Implement conditional logic for 5-day vs 7-day modes
+  - Update IMS week logic based on feature flag
+  - Document feature flag usage
+- **Files**: apps/timesheet/services/weekly_timesheet_service.py, apps/workflow/models/company_defaults.py
+- **Priority**: High
+
+#### TASK-008: Query Optimization
+- **Description**: Optimize queries for 7-day data processing
+- **Subtasks**:
+  - Review query performance with larger date ranges
+  - Optimize JSON field queries for weekend dates
+  - Check database indexes support weekend queries
+  - Monitor memory usage with 7-day structures
+- **Files**: All query-heavy files
+- **Priority**: Medium
+
+### 5. Quality Assurance (Medium Priority)
+
+#### TASK-009: Manual Validation
+- **Description**: Perform manual validation of weekend functionality
+- **Subtasks**:
+  - Test weekly overview with weekend data manually
+  - Verify daily views work for weekends
+  - Test leave submission for weekend dates
+  - Validate export functionality manually
+- **Files**: All modified files
+- **Priority**: Medium
+
+#### TASK-010: Code Review
+- **Description**: Review code changes for quality and consistency
+- **Subtasks**:
+  - Check for hardcoded weekday assumptions
+  - Verify feature flag implementation
+  - Review error handling and logging
+  - Validate API documentation updates
+- **Files**: All modified files
+- **Priority**: Medium
+
+### 6. Documentation and Communication (Low Priority)
+
+#### TASK-011: API Documentation Updates
+- **Description**: Update all API documentation to reflect weekend support
+- **Subtasks**:
+  - Update OpenAPI schemas
+  - Fix docstrings mentioning weekday-only
+  - Update developer documentation
+  - Create weekend-specific examples
+- **Files**: View files, documentation
+- **Priority**: Low
+
+#### TASK-012: Code Comments and Logging
+- **Description**: Update code comments to reflect weekend support
+- **Subtasks**:
+  - Remove weekday-only comments
+  - Add weekend-specific logging
+  - Update method docstrings
+  - Document weekend business rules
+- **Files**: All modified files
+- **Priority**: Low
+
+## Implementation Order
+
+### Phase 1: Core Backend (Week 1)
+1. TASK-001: Verify WeeklyTimesheetService Integration
+2. TASK-002: Update Response Builders
+3. TASK-003: Modern Timesheet Views Audit
+4. TASK-004: Daily Timesheet Service Integration
+
+### Phase 2: Validation and Business Logic (Week 1)
+5. TASK-005: Remove Weekday-Only Validations
+6. TASK-006: Business Logic Updates
+
+### Phase 3: Integration and Exports (Week 2)
+7. TASK-007: Export Services Audit
+13. TASK-013: Feature Flag Implementation
+8. TASK-008: Query Optimization
+
+### Phase 4: Quality Assurance and Documentation (Week 2)
+9. TASK-009: Manual Validation
+10. TASK-010: Code Review
+11. TASK-011: API Documentation Updates
+12. TASK-012: Code Comments and Logging
+
+## Success Metrics
+
+### Technical Metrics
+- [ ] Query performance within 10% of baseline
+- [ ] Memory usage acceptable for 7-day structures
+- [ ] No breaking changes to existing functionality
+- [ ] Feature flag works correctly
+
+### Functional Metrics
+- [ ] Weekly overviews show 7 days of data
+- [ ] Weekend dates can be queried individually
+- [ ] Leave submissions work for weekend dates
+- [ ] Time entries can be created for weekends
+- [ ] All calculations work with 7-day data
+
+### Quality Metrics
+- [ ] Code coverage maintained above 80%
+- [ ] No new security vulnerabilities
+- [ ] API contracts maintained
+- [ ] Documentation updated
+
+## Risk Mitigation
+
+### High Risk Items
+- **Performance Degradation**: Monitor query performance, optimize if needed
+- **Test Failures**: Run comprehensive test suite before deployment
+- **API Breaking Changes**: Maintain backward compatibility
+
+### Contingency Plans
+- **Rollback Plan**: Database backup and code rollback procedures
+- **Feature Flags**: Implement feature flags for weekend functionality
+- **Gradual Rollout**: Deploy to staging first, then production
+
+## Dependencies
+
+### Internal Dependencies
+- Database performance monitoring
+- Frontend team availability for UI updates
+- Manual validation by development team
+
+### External Dependencies
+- Third-party service compatibility
+- Export format requirements
+- Business stakeholder approval
+
+## Communication Plan
+
+### Weekly Updates
+- Monday: Sprint planning and task assignment
+- Wednesday: Mid-week progress check
+- Friday: End-of-week status and blockers
+
+### Stakeholders
+- Development Team: Daily standups
+- Product Owner: Feature validation
+- Business Users: Manual validation and acceptance testing
+
+## Timeline
+
+### Week 1: Core Implementation
+- Days 1-2: Backend service updates
+- Days 3-4: View layer updates
+- Day 5: Validation removal and business logic
+
+### Week 2: Integration and Quality Assurance
+- Days 1-2: Export services and optimization
+- Days 3-4: Manual validation and code review
+- Day 5: Documentation and final validation
+
+Total Tasks: 13
+Critical Path: TASK-001 → TASK-002 → TASK-003 → TASK-013 → TASK-009

--- a/apps/timesheet/serializers/daily_timesheet_serializers.py
+++ b/apps/timesheet/serializers/daily_timesheet_serializers.py
@@ -40,6 +40,9 @@ class StaffDailyDataSerializer(serializers.Serializer):
     job_breakdown = JobBreakdownSerializer(many=True)
     entry_count = serializers.IntegerField()
     alerts = serializers.ListField(child=serializers.CharField())
+    # Weekend-related fields
+    is_weekend = serializers.BooleanField(required=False, default=False)
+    weekend_enabled = serializers.BooleanField(required=False, default=False)
 
 
 class DailyTotalsSerializer(serializers.Serializer):
@@ -74,6 +77,10 @@ class DailyTimesheetSummarySerializer(serializers.Serializer):
     staff_data = StaffDailyDataSerializer(many=True)
     daily_totals = DailyTotalsSerializer()
     summary_stats = SummaryStatsSerializer()
+    # Weekend-related fields
+    weekend_enabled = serializers.BooleanField(required=False, default=False)
+    is_weekend = serializers.BooleanField(required=False, default=False)
+    day_type = serializers.CharField(required=False, allow_blank=True)
 
 
 class TimesheetErrorResponseSerializer(serializers.Serializer):

--- a/apps/timesheet/serializers/modern_timesheet_serializers.py
+++ b/apps/timesheet/serializers/modern_timesheet_serializers.py
@@ -103,6 +103,9 @@ class WeeklyTimesheetDataSerializer(serializers.Serializer):
     export_mode = serializers.CharField()
     is_current_week = serializers.BooleanField()
     navigation = serializers.DictField(required=False)
+    # Weekend-related fields
+    weekend_enabled = serializers.BooleanField(required=False, default=False)
+    week_type = serializers.CharField(required=False, allow_blank=True)
 
 
 class IMSWeeklyStaffDataWeeklyHoursSerializer(serializers.Serializer):


### PR DESCRIPTION
This commit introduces the core changes to enable weekend timesheet functionality, controlled by a `WEEKEND_TIMESHEETS_ENABLED` feature flag.

**Key Changes:**

* **`WeeklyTimesheetService`**:
 * `_get_week_days()` now returns 7 days (Monday-Sunday) when the feature flag is enabled, otherwise it returns 5 days (Monday-Friday).
 * Leave auto-creation logic no longer skips weekends, allowing leave entries for Saturday and Sunday.
 * Staff ordering changed to `first_name`, `last_name` for consistency.
* **`DailyTimesheetService`**:
 * Introduces `_is_weekend_enabled()` to check the feature flag.
 * `_get_scheduled_hours()` now returns 0 for weekends when the feature flag is enabled, and skips staff with no scheduled hours on weekdays only.
 * `_determine_status()` includes a new "Weekend Work" status for entries on weekends when the feature flag is enabled.
* **API Views (`DailyTimesheetAPIView`, `WeeklyTimesheetAPIView`)**:
 * `DailyTimesheetAPIView` now includes `is_weekend` and `weekend_enabled` flags in the response for individual staff and daily summaries.
 * `TimesheetResponseMixin` (used by `WeeklyTimesheetAPIView`) now passes the `weekend_enabled` flag to the serializer and includes `week_type` in the response.
 * API documentation summaries are updated to reflect 5-day or 7-day behavior based on the feature flag.
* **Serializers (`daily_timesheet_serializers.py`, `modern_timesheet_serializers.py`)**:
 * Added `is_weekend`, `weekend_enabled`, `day_type`, and `week_type` fields to relevant serializers to expose weekend status and feature flag state to the frontend.
* **Documentation**:
 * Added new architecture, requirements, and task markdown files (`.kilocode/tasks/weekend_timesheet_architecture.md`, `.kilocode/tasks/weekend_timesheet_requirements.md`, `.kilocode/tasks/weekend_timesheet_tasks.md`) outlining the plan for weekend inclusion, including the feature flag strategy.

**Why these changes?**

The primary goal is to allow users to track and manage timesheet entries for weekends, which was previously not supported. The feature flag ensures backward compatibility and allows for a controlled rollout of this new functionality. By including weekend data in the service and API layers, the system becomes more flexible and comprehensive for time tracking. The new documentation files provide a clear roadmap and rationale for these changes.

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**
- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**
- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
