### PR TITLE
fix(workshop_pdf_service): ensure contact name is empty string when n…

### DIFF
--- a/apps/job/services/workshop_pdf_service.py
+++ b/apps/job/services/workshop_pdf_service.py
@@ -259,7 +259,7 @@ def add_title(pdf, y_position, job):
 def add_job_details_table(pdf, y_position, job: Job):
     """Render the job details with a coloured header row and improved spacing."""
     client_name = job.client.name if job.client else "N/A"
-    contact_name = job.contact.name if job.contact else "N/A"
+    contact_name = job.contact.name if job.contact else ""
 
     # Use Paragraph styles so header text is white over the blue background
     job_details = [


### PR DESCRIPTION
…ot available

The `contact_name` variable is now initialized to an empty string instead of "N/A" when `job.contact` is `None`. This change ensures that the PDF output for the contact name field is blank when no contact is associated with the job, providing a cleaner and more accurate representation in the generated document.
