### PR TITLE
refactor: remove hardcoded paths and company-specific references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ AUTH_COOKIE_DOMAIN=.loca.lt
 APP_DOMAIN=your-domain.ngrok-free.app
 
 # Path to Dropbox workflow folder - use quotes if path contains spaces
-DROPBOX_WORKFLOW_FOLDER="C:\Users\YourUser\Dropbox\MSM Workflow"
+DROPBOX_WORKFLOW_FOLDER="C:\Users\YourUser\Dropbox\Your Workflow Folder"
 
 # Google Sheets API credentials
 GCP_CREDENTIALS="/path/to/google-service-account-key.json"

--- a/adhoc/check_ai_providers.py
+++ b/adhoc/check_ai_providers.py
@@ -5,7 +5,7 @@ import sys
 import django
 
 # Setup Django
-sys.path.append("/home/corrin/src/jobs_manager")
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobs_manager.settings")
 django.setup()
 

--- a/adhoc/debug_xero_serialization.py
+++ b/adhoc/debug_xero_serialization.py
@@ -4,7 +4,7 @@ import sys
 import django
 
 # Setup Django
-sys.path.append("/home/corrin/src/jobs_manager")
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobs_manager.settings")
 django.setup()
 

--- a/adhoc/test_google_drive.py
+++ b/adhoc/test_google_drive.py
@@ -10,7 +10,7 @@ import django
 from googleapiclient.discovery import build
 
 # Setup Django
-sys.path.append("/home/corrin/src/jobs_manager")
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobs_manager.settings")
 django.setup()
 

--- a/adhoc/test_pdf_parsing.py
+++ b/adhoc/test_pdf_parsing.py
@@ -16,7 +16,9 @@ from apps.workflow.models import AIProvider
 
 def test_pdf_parsing():
     """Test PDF parsing functionality with sample files."""
-    pdf_dir = "/home/corrin/src/jobs_manager/docs/test_pdfs/price_lists"
+    # Get the project root directory
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    pdf_dir = os.path.join(project_root, "docs", "test_pdfs", "price_lists")
     pdf_files = [
         "Copy of ST Flat Product Morris sheetmetal 5.05.2025 1.pdf",
         "Morris SM - Extrusions & Rolled Stock.pdf",

--- a/apps/job/services/gemini_chat_service.py
+++ b/apps/job/services/gemini_chat_service.py
@@ -23,7 +23,7 @@ from apps.job.models import Job, JobQuoteChat
 from apps.job.services.quote_mode_controller import QuoteModeController
 from apps.quoting.mcp import QuotingTool, SupplierProductQueryTool
 from apps.workflow.enums import AIProviderTypes
-from apps.workflow.models import AIProvider
+from apps.workflow.models import AIProvider, CompanyDefaults
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,8 @@ class GeminiChatService:
 
     def _get_system_prompt(self, job: Job) -> str:
         """Generate system prompt with job context for Gemini."""
-        return f"""You are an intelligent quoting assistant for Morris Sheetmetal Works,
+        company = CompanyDefaults.objects.first()
+        return f"""You are an intelligent quoting assistant for {company.company_name},
 a custom metal fabrication business. Your role is to help estimators create accurate
 quotes by using the available tools to find material pricing, compare suppliers,
 and generate estimates.

--- a/apps/job/services/mcp_chat_service.py
+++ b/apps/job/services/mcp_chat_service.py
@@ -23,7 +23,7 @@ from django.db import transaction
 from apps.job.models import Job, JobQuoteChat
 from apps.quoting.mcp import QuotingTool, SupplierProductQueryTool
 from apps.workflow.enums import AIProviderTypes  # NEW
-from apps.workflow.models import AIProvider
+from apps.workflow.models import AIProvider, CompanyDefaults
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,8 @@ class MCPChatService:
 
     def _get_system_prompt(self, job: Job) -> str:
         """Generate system prompt with job context and MCP tool descriptions."""
-        return f"""You are an intelligent quoting assistant for Morris Sheetmetal Works,
+        company = CompanyDefaults.objects.first()
+        return f"""You are an intelligent quoting assistant for {company.company_name},
 a sheet metal jobbing shop.
 
 Current Job Context:

--- a/apps/purchasing/services/purchase_order_email_service.py
+++ b/apps/purchasing/services/purchase_order_email_service.py
@@ -29,12 +29,16 @@ def create_purchase_order_email(purchase_order: PurchaseOrder) -> dict:
 
     email = purchase_order.supplier.email
 
+    from apps.workflow.models import CompanyDefaults
+
+    company = CompanyDefaults.objects.first()
+
     subject = f"Purchase Order {purchase_order.po_number}"
     body = (
         f"Hi,\n\n"
         f"Please find attached Purchase Order #{purchase_order.po_number}.\n\n"
         f"If you have any questions about this order, please reply to this e-mail.\n\n"
-        f"Thanks,\nMorris Sheetmetals Ltd."
+        f"Thanks,\n{company.company_name}"
     )
 
     mailto_url = f"mailto:{email}?subject={quote(subject)}&body={quote(body)}"

--- a/jobs_manager/settings.py
+++ b/jobs_manager/settings.py
@@ -288,7 +288,7 @@ LOGIN_EXEMPT_URLS = [
 
 # For OpenAPI schema generator
 SPECTACULAR_SETTINGS = {
-    "TITLE": "MSM Jobs Manager API",
+    "TITLE": "Jobs Manager API",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
 }


### PR DESCRIPTION
- Replace hardcoded /home/corrin paths with relative paths in adhoc scripts
- Pull company name from CompanyDefaults instead of hardcoding
- Generalize API title from "MSM Jobs Manager" to "Jobs Manager"
- Update .env.example to remove company-specific example

These changes make the codebase more portable and suitable for open-sourcing while maintaining all functionality through configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**

- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**

- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
