### PR TITLE
Fix CI/CD deployment failure in UAT

### DIFF
--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -71,8 +71,8 @@ update_code() {
 
     cd "$PROJECT_PATH"
 
-    # Check if branch exists locally
-    git switch main
+    # Ensure we're on main branch and clean any local changes
+    git checkout main || git checkout -b main origin/main
 
     # Pull latest changes and force sync with remote
     git fetch origin main

--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -72,7 +72,7 @@ update_code() {
     cd "$PROJECT_PATH"
 
     # Ensure we're on main branch and clean any local changes
-    git checkout main || git checkout -b main origin/main
+    git checkout main
 
     # Pull latest changes and force sync with remote
     git fetch origin main

--- a/scripts/deploy_machine.sh
+++ b/scripts/deploy_machine.sh
@@ -71,7 +71,10 @@ update_code() {
 
     cd "$PROJECT_PATH"
 
-    # Ensure we're on main branch and clean any local changes
+    # Clean any local changes to tracked files
+    git reset --hard
+
+    # Ensure we're on main branch
     git checkout main
 
     # Pull latest changes and force sync with remote


### PR DESCRIPTION
## Summary
- Fix deployment script to handle dirty working directory
- Add git reset before checkout to avoid 'local changes would be overwritten' errors
- Preserve local config files by not using git clean

## Problem
The CI/CD deployment was failing with:
```
Waiter CommandExecuted failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "Failed"
```

## Solution
The deployment script now properly resets tracked files before switching branches, ensuring a clean state without removing important local configuration files.

## Trello
https://trello.com/c/yYNHCNM8/101-ci-cd-has-broken-in-uat

🤖 Generated with [Claude Code](https://claude.ai/code)