### PR TITLE
feat: add CostSet/CostLine support to json_to_mysql converter

### DIFF
--- a/scripts/json_to_mysql.py
+++ b/scripts/json_to_mysql.py
@@ -20,6 +20,7 @@ class JSONToMySQLConverter:
             "action_time",
             "applied",
             "completed_at",
+            "created",
             "created_at",
             "created_date_utc",
             "date",
@@ -30,6 +31,7 @@ class JSONToMySQLConverter:
             "expire_date",
             "history_date",
             "last_login",
+            "last_scraped",
             "last_xero_deep_sync",
             "last_xero_sync",
             "next_run_time",
@@ -53,6 +55,9 @@ class JSONToMySQLConverter:
             "raw_ims_data",
             "additional_contact_persons",
             "all_phones",
+            "ext_refs",
+            "meta",
+            "summary",
         }
 
         # Mapping from Django model names to MySQL table names
@@ -64,6 +69,8 @@ class JSONToMySQLConverter:
             "job.adjustmententry": "workflow_adjustmententry",
             "job.jobevent": "workflow_jobevent",
             "job.jobfile": "workflow_jobfile",
+            "job.costset": "job_costset",
+            "job.costline": "job_costline",
             "timesheet.timeentry": "workflow_timeentry",
             "accounts.staff": "workflow_staff",
             "client.client": "workflow_client",
@@ -87,6 +94,9 @@ class JSONToMySQLConverter:
                 "latest_estimate_pricing": "latest_estimate_pricing_id",
                 "latest_quote_pricing": "latest_quote_pricing_id",
                 "latest_reality_pricing": "latest_reality_pricing_id",
+                "latest_estimate": "latest_estimate_id",
+                "latest_quote": "latest_quote_id",
+                "latest_actual": "latest_actual_id",
             },
             "workflow_jobpricing": {
                 "job": "job_id",
@@ -128,6 +138,12 @@ class JSONToMySQLConverter:
             },
             "quoting_scrapejob": {
                 "supplier": "supplier_id",
+            },
+            "job_costset": {
+                "job": "job_id",
+            },
+            "job_costline": {
+                "cost_set": "cost_set_id",
             },
         }
 


### PR DESCRIPTION
- Add datetime fields: created, last_scraped
- Add JSON fields: ext_refs, meta, summary
- Add table mappings for job_costset and job_costline
- Add foreign key mappings for new pricing model relationships

These changes enable proper backup/restore of the new CostSet/CostLine pricing model data.

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**

- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**

- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
