### PR TITLE
Fix CD deployment permission error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids $SCHEDULER_INSTANCE_ID \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=['sudo su - ubuntu -c \"$PROJECT_PATH/scripts/deploy_machine.sh main scheduler\"']" \
+            --parameters "commands=['sudo su - ubuntu -c \"bash $PROJECT_PATH/scripts/deploy_machine.sh main scheduler\"']" \
             --region $AWS_REGION \
             --query 'Command.CommandId' \
             --output text)
@@ -101,7 +101,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids $FRONTEND_INSTANCE_ID \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=['sudo su - ubuntu -c \"$PROJECT_PATH/scripts/deploy_machine.sh main frontend\"']" \
+            --parameters "commands=['sudo su - ubuntu -c \"bash $PROJECT_PATH/scripts/deploy_machine.sh main frontend\"']" \
             --region $AWS_REGION \
             --query 'Command.CommandId' \
             --output text)


### PR DESCRIPTION
## Summary
- Fixed CD workflow failing due to missing execute permissions on deploy_machine.sh
- Changed deployment commands to explicitly use bash to run the script

## Problem
The CD pipeline was failing with "Permission denied" when trying to execute deploy_machine.sh

## Solution
Modified both deployment steps to use bash explicitly:
- Line 44: Scheduler deployment command
- Line 104: Frontend deployment command

## Test Plan
This PR will test the CD pipeline when merged to main