### PR TITLE
fix: simplify scheduler configuration for production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,10 +75,6 @@ EMAIL_BCC=admin@yourcompany.com
 # Django environment setting
 DJANGO_ENV=production_like
 
-# UAT Scheduler Control - Set to true to disable APScheduler on this machine
-# Only needed when you want to distribute the load across multiple machines
-# Set to true to rely on scheduler running on a different machine
-USE_EXTERNAL_SCHEDULER=false
 
 # Xero webhook verification key
 XERO_WEBHOOK_KEY=XERO_WEBHOOK_SIGNING_KEY_GOES_HERE

--- a/apps/workflow/__init__.py
+++ b/apps/workflow/__init__.py
@@ -28,12 +28,7 @@ try:
             PasswordStrengthMiddleware,
         )
         from .permissions import F
-        from .scheduler import (
-            get_scheduler,
-            should_start_scheduler,
-            start_scheduler,
-            stop_scheduler,
-        )
+        from .scheduler import get_scheduler, stop_scheduler
         from .scheduler_jobs import (
             xero_30_day_sync_job,
             xero_heartbeat_job,
@@ -122,8 +117,6 @@ __all__ = [
     "process_webhook_event",
     "process_webhook_queue",
     "service_api_key_required",
-    "should_start_scheduler",
-    "start_scheduler",
     "stop_scheduler",
     "validate_webhook_signature",
     "xero_30_day_sync_job",

--- a/apps/workflow/scheduler.py
+++ b/apps/workflow/scheduler.py
@@ -7,7 +7,6 @@ once at import time and can be started/stopped as needed.
 """
 
 import logging
-import os
 from typing import Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -31,55 +30,6 @@ def get_scheduler() -> BackgroundScheduler:
 
         scheduler.add_jobstore(DjangoJobStore(), "default")
     return scheduler
-
-
-def should_start_scheduler() -> bool:
-    """
-    Determine if the scheduler should be started in the current context.
-
-    Checks:
-    1. DJANGO_RUN_SCHEDULER must be "1" (existing requirement)
-    2. USE_EXTERNAL_SCHEDULER must be explicitly set (required configuration)
-    """
-    # Primary control - must be enabled
-    if os.getenv("DJANGO_RUN_SCHEDULER") != "1":
-        return False
-
-    # External scheduler control - must be explicitly configured
-    external_scheduler = os.getenv("USE_EXTERNAL_SCHEDULER")
-    if external_scheduler is None:
-        raise ValueError(
-            "USE_EXTERNAL_SCHEDULER environment variable must be set to 'true' or 'false'"
-        )
-
-    if external_scheduler.lower() == "true":
-        logger.info(
-            "Using external scheduler - local scheduler disabled via USE_EXTERNAL_SCHEDULER environment variable"
-        )
-        return False
-
-    return True
-
-
-def start_scheduler() -> bool:
-    """
-    Start the scheduler if appropriate conditions are met.
-
-    Returns:
-        bool: True if scheduler was started, False if it was already running or
-              shouldn't start
-    """
-    if not should_start_scheduler():
-        return False
-
-    try:
-        scheduler_instance = get_scheduler()
-        scheduler_instance.start()
-        logger.info("Shared APScheduler started successfully")
-        return True
-    except Exception as e:
-        logger.error(f"Error starting shared APScheduler: {e}", exc_info=True)
-        return False
 
 
 def stop_scheduler() -> bool:


### PR DESCRIPTION
Remove USE_EXTERNAL_SCHEDULER environment variable that was causing conflicts in production where web server and scheduler share the same .env file.

Changes:
- Remove USE_EXTERNAL_SCHEDULER from .env.example
- Simplify run_scheduler command to directly start scheduler without checks
- Remove unused should_start_scheduler() and start_scheduler() functions
- Update autogenerated __init__.py files

The scheduler now starts directly when run_scheduler command is called, eliminating environment variable conflicts between web and scheduler processes.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**

- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**

- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
