### PR TITLE
Fix: Add line numbers to verbose logging format

### DIFF
--- a/apps/job/views/job_rest_views.py
+++ b/apps/job/views/job_rest_views.py
@@ -590,16 +590,20 @@ class JobHeaderRestView(BaseJobRestView):
                 "job_id": str(job.id),
                 "job_number": job.job_number,
                 "name": job.name,
-                "client": {"id": str(job.client.id), "name": job.client.name}
-                if job.client
-                else None,
+                "client": (
+                    {"id": str(job.client.id), "name": job.client.name}
+                    if job.client
+                    else None
+                ),
                 "status": job.status,
                 "pricing_methodology": job.pricing_methodology,
                 "fully_invoiced": job.fully_invoiced,
                 "quoted": job.quoted,
-                "quote_acceptance_date": job.quote_acceptance_date.isoformat()
-                if job.quote_acceptance_date
-                else None,
+                "quote_acceptance_date": (
+                    job.quote_acceptance_date.isoformat()
+                    if job.quote_acceptance_date
+                    else None
+                ),
                 "paid": job.paid,
             }
 
@@ -714,48 +718,72 @@ class JobCostSummaryRestView(BaseJobRestView):
 
             # Build frontend-expected summary data with profitMargin
             summary_data = {
-                "estimate": {
-                    "cost": estimate.summary.get("cost", 0)
+                "estimate": (
+                    {
+                        "cost": (
+                            estimate.summary.get("cost", 0)
+                            if estimate and estimate.summary
+                            else 0
+                        ),
+                        "rev": (
+                            estimate.summary.get("rev", 0)
+                            if estimate and estimate.summary
+                            else 0
+                        ),
+                        "hours": (
+                            estimate.summary.get("hours", 0)
+                            if estimate and estimate.summary
+                            else 0
+                        ),
+                        "profitMargin": calculate_profit_margin(estimate),
+                    }
                     if estimate and estimate.summary
-                    else 0,
-                    "rev": estimate.summary.get("rev", 0)
-                    if estimate and estimate.summary
-                    else 0,
-                    "hours": estimate.summary.get("hours", 0)
-                    if estimate and estimate.summary
-                    else 0,
-                    "profitMargin": calculate_profit_margin(estimate),
-                }
-                if estimate and estimate.summary
-                else None,
-                "quote": {
-                    "cost": quote.summary.get("cost", 0)
+                    else None
+                ),
+                "quote": (
+                    {
+                        "cost": (
+                            quote.summary.get("cost", 0)
+                            if quote and quote.summary
+                            else 0
+                        ),
+                        "rev": (
+                            quote.summary.get("rev", 0)
+                            if quote and quote.summary
+                            else 0
+                        ),
+                        "hours": (
+                            quote.summary.get("hours", 0)
+                            if quote and quote.summary
+                            else 0
+                        ),
+                        "profitMargin": calculate_profit_margin(quote),
+                    }
                     if quote and quote.summary
-                    else 0,
-                    "rev": quote.summary.get("rev", 0)
-                    if quote and quote.summary
-                    else 0,
-                    "hours": quote.summary.get("hours", 0)
-                    if quote and quote.summary
-                    else 0,
-                    "profitMargin": calculate_profit_margin(quote),
-                }
-                if quote and quote.summary
-                else None,
-                "actual": {
-                    "cost": actual.summary.get("cost", 0)
+                    else None
+                ),
+                "actual": (
+                    {
+                        "cost": (
+                            actual.summary.get("cost", 0)
+                            if actual and actual.summary
+                            else 0
+                        ),
+                        "rev": (
+                            actual.summary.get("rev", 0)
+                            if actual and actual.summary
+                            else 0
+                        ),
+                        "hours": (
+                            actual.summary.get("hours", 0)
+                            if actual and actual.summary
+                            else 0
+                        ),
+                        "profitMargin": calculate_profit_margin(actual),
+                    }
                     if actual and actual.summary
-                    else 0,
-                    "rev": actual.summary.get("rev", 0)
-                    if actual and actual.summary
-                    else 0,
-                    "hours": actual.summary.get("hours", 0)
-                    if actual and actual.summary
-                    else 0,
-                    "profitMargin": calculate_profit_margin(actual),
-                }
-                if actual and actual.summary
-                else None,
+                    else None
+                ),
             }
 
             serializer = JobCostSummaryResponseSerializer(summary_data)

--- a/jobs_manager/settings.py
+++ b/jobs_manager/settings.py
@@ -638,7 +638,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "{levelname} {asctime} {module} {message}",
+            "format": "{levelname} {asctime} {name}:{lineno} {message}",
             "style": "{",
         },
         "simple": {

--- a/scripts/recreate_jobfiles.py
+++ b/scripts/recreate_jobfiles.py
@@ -4,10 +4,10 @@ Create dummy files for JobFile records after production restore.
 Part of Step 14 in the backup/restore process.
 """
 
-import os
-import sys
-import subprocess
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 # Add project root to path
@@ -16,10 +16,12 @@ sys.path.insert(0, str(project_root))
 os.chdir(project_root)
 
 import django
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'jobs_manager.settings')
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobs_manager.settings")
 django.setup()
 
 from django.conf import settings
+
 from apps.job.models import JobFile
 
 logger = logging.getLogger(__name__)
@@ -31,45 +33,58 @@ def create_dummy_file(filepath, job_name, job_number, filename):
 
     ext = os.path.splitext(filename)[1].lower()
 
-    if ext == '.pdf':
+    if ext == ".pdf":
         # Create PDF using pandoc with wkhtmltopdf engine
-        content = f"# Job: {job_name}\n\n**Number:** {job_number}\n\nDummy PDF for {filename}"
+        content = (
+            f"# Job: {job_name}\n\n**Number:** {job_number}\n\nDummy PDF for {filename}"
+        )
         process = subprocess.run(
-            ['pandoc', '-o', filepath, '--pdf-engine=wkhtmltopdf', '--metadata', f'pagetitle=Job {job_number}'],
+            [
+                "pandoc",
+                "-o",
+                filepath,
+                "--pdf-engine=wkhtmltopdf",
+                "--metadata",
+                f"pagetitle=Job {job_number}",
+            ],
             input=content,
             text=True,
-            capture_output=True
+            capture_output=True,
         )
         if process.returncode != 0:
             raise Exception(f"Failed to create PDF: {process.stderr}")
 
-    elif ext in ['.png', '.jpg', '.jpeg']:
+    elif ext in [".png", ".jpg", ".jpeg"]:
         # Create image using ImageMagick convert
-        subprocess.run([
-            'convert',
-            '-size', '400x200',
-            'xc:white',
-            '-pointsize', '20',
-            '-draw', f'text 10,30 "Job: {job_name}"',
-            '-draw', f'text 10,60 "Number: {job_number}"',
-            filepath
-        ], check=True)
+        subprocess.run(
+            [
+                "convert",
+                "-size",
+                "400x200",
+                "xc:white",
+                "-pointsize",
+                "20",
+                "-draw",
+                f'text 10,30 "Job: {job_name}"',
+                "-draw",
+                f'text 10,60 "Number: {job_number}"',
+                filepath,
+            ],
+            check=True,
+        )
 
-    elif ext in ['.docx', '.doc']:
+    elif ext in [".docx", ".doc"]:
         # Create Word document using pandoc
         content = f"# Job: {job_name}\n\n**Number:** {job_number}\n\nDummy document for {filename}"
         process = subprocess.run(
-            ['pandoc', '-o', filepath],
-            input=content,
-            text=True,
-            capture_output=True
+            ["pandoc", "-o", filepath], input=content, text=True, capture_output=True
         )
         if process.returncode != 0:
             raise Exception(f"Failed to create DOCX: {process.stderr}")
 
-    elif ext == '.eml':
+    elif ext == ".eml":
         # Create email file (RFC 822 format)
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(
                 f"From: dummy@example.com\n"
                 f"To: user@example.com\n"
@@ -79,38 +94,39 @@ def create_dummy_file(filepath, job_name, job_number, filename):
                 f"Job: {job_name}\nNumber: {job_number}\nFile: {filename}\n"
             )
 
-    elif ext == '.txt':
+    elif ext == ".txt":
         # Create text file
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(f"Job: {job_name}\nNumber: {job_number}\nFile: {filename}\n")
 
-    elif ext == '.zip':
+    elif ext == ".zip":
         # Create minimal zip file
         import zipfile
-        with zipfile.ZipFile(filepath, 'w') as zf:
-            zf.writestr('readme.txt', f"Job: {job_name}\nNumber: {job_number}\nFile: {filename}\n")
 
-    elif ext in ['.xlsx', '.xlsm']:
+        with zipfile.ZipFile(filepath, "w") as zf:
+            zf.writestr(
+                "readme.txt",
+                f"Job: {job_name}\nNumber: {job_number}\nFile: {filename}\n",
+            )
+
+    elif ext in [".xlsx", ".xlsm"]:
         # Create Excel file using pandas
         import pandas as pd
-        df = pd.DataFrame({
-            'Job': [job_name],
-            'Number': [job_number],
-            'File': [filename]
-        })
+
+        df = pd.DataFrame(
+            {"Job": [job_name], "Number": [job_number], "File": [filename]}
+        )
         df.to_excel(filepath, index=False)
 
     else:
         # For all other extensions (.dxf, .step, .py, .conf, etc), create text file
         logger.info(f"Creating text placeholder for: {filename} (extension: {ext})")
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(f"Job: {job_name}\nNumber: {job_number}\nFile: {filename}\n")
 
 
 def main():
-    job_files = JobFile.objects.filter(
-        file_path__isnull=False
-    ).exclude(file_path='')
+    job_files = JobFile.objects.filter(file_path__isnull=False).exclude(file_path="")
 
     total = job_files.count()
     created = 0

--- a/test_gzip.py
+++ b/test_gzip.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 import requests
 
-url = 'http://localhost:8000/job/rest/jobs/7389bef8-6544-4f7a-8c49-e6e3e5feedf7/cost-sets/estimate/'
-headers = {'Accept': 'application/json', 'Accept-Encoding': 'gzip'}
+url = "http://localhost:8000/job/rest/jobs/7389bef8-6544-4f7a-8c49-e6e3e5feedf7/cost-sets/estimate/"
+headers = {"Accept": "application/json", "Accept-Encoding": "gzip"}
 
-print('Testing gzip compression on localhost...')
+print("Testing gzip compression on localhost...")
 response = requests.get(url, headers=headers)
 
-print(f'Status: {response.status_code}')
+print(f"Status: {response.status_code}")
 print(f'Content-Encoding: {response.headers.get("Content-Encoding", "none")}')
 print(f'Content-Length: {response.headers.get("Content-Length", "unknown")}')
-print(f'Actual response size: {len(response.content):,} bytes')
+print(f"Actual response size: {len(response.content):,} bytes")
 print(f'Compressed: {"gzip" in response.headers.get("Content-Encoding", "")}')


### PR DESCRIPTION
## Summary
- Added line numbers to the verbose logging formatter to improve debugging
- Changed format from `{module}` to `{name}:{lineno}` to show full logger path and line number

## Problem
Error messages like `'NoneType' object has no attribute 'id'` were being logged without line numbers, making it extremely difficult to identify where errors actually occurred in the code.

## Solution
Updated the Django logging configuration to include `{name}:{lineno}` in the verbose formatter, which will now show:
- The full logger name (e.g., `apps.workflow.api.xero.sync`)
- The exact line number where the log was generated

This change affects all loggers using the verbose formatter, improving debuggability across the entire application.

## Test Plan
- [x] Updated logging configuration
- [ ] Test that error logs now include line numbers
- [ ] Verify no breaking changes to existing log parsing tools

🤖 Generated with [Claude Code](https://claude.ai/code)