### PR TITLE
fix: allow negative values for adjustment cost lines

### DIFF
--- a/apps/job/models/costing.py
+++ b/apps/job/models/costing.py
@@ -124,10 +124,7 @@ class CostLine(models.Model):
                 f"CostLine has negative quantity: {self.quantity} for {self.desc}"
             )
 
-        if self.unit_cost < 0:
-            raise ValidationError("Unit cost must be non-negative")
-        if self.unit_rev < 0:
-            raise ValidationError("Unit revenue must be non-negative")
+        # Allow negative values for adjustments, discounts, credits, etc.
 
     def _update_cost_set_summary(self) -> None:
         """Update cost set summary with aggregated data - PRESERVE existing data"""

--- a/apps/job/serializers/costing_serializer.py
+++ b/apps/job/serializers/costing_serializer.py
@@ -164,17 +164,15 @@ class CostLineCreateUpdateSerializer(serializers.ModelSerializer):
         return value
 
     def validate_unit_cost(self, value):
-        """Validate unit cost is non-negative"""
+        """Validate unit cost - allow negative values for adjustments"""
         logger.info(f"Validating unit_cost: {value} (type: {type(value)})")
-        if value < 0:
-            raise serializers.ValidationError("Unit cost must be non-negative")
+        # Allow negative values for adjustments, discounts, credits
         return value
 
     def validate_unit_rev(self, value):
-        """Validate unit revenue is non-negative"""
+        """Validate unit revenue - allow negative values for adjustments"""
         logger.info(f"Validating unit_rev: {value} (type: {type(value)})")
-        if value < 0:
-            raise serializers.ValidationError("Unit revenue must be non-negative")
+        # Allow negative values for adjustments, discounts, credits
         return value
 
     def save(self, **kwargs):


### PR DESCRIPTION
Previously, the CostLine model and serializer validation was rejecting negative unit_cost and unit_rev values, which prevented users from creating negative adjustments (discounts, credits, corrections).

This was causing invoices to be incorrect as adjustments couldn't be saved, leading to invoice totals not matching the actual job totals.

Changes:
- Removed validation that prevented negative unit_cost and unit_rev
- Adjustments, discounts, and credits can now have negative values
- This allows invoices to properly include all cost lines (T+M+A)

Fixes: https://trello.com/c/jNLcplD7/116-jm-not-invoicing-properly-from-total-revenue-amount-when-adjusted

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**

- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**

- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
