### PR TITLE
Fix: Accept quote now changes job status to approved

### DIFF
--- a/apps/job/services/job_rest_service.py
+++ b/apps/job/services/job_rest_service.py
@@ -215,9 +215,9 @@ class JobRestService:
 
         return {
             "description": job.description or "",
-            "delivery_date": job.delivery_date.isoformat()
-            if job.delivery_date
-            else None,
+            "delivery_date": (
+                job.delivery_date.isoformat() if job.delivery_date else None
+            ),
             "order_number": job.order_number or "",
             "notes": job.notes or "",
         }
@@ -505,7 +505,7 @@ class JobRestService:
     @staticmethod
     def accept_quote(job_id: UUID, user: Staff) -> Dict[str, Any]:
         """
-        Accept a quote for a job by setting the quote_acceptance_date.
+        Accept a quote for a job by setting the quote_acceptance_date and changing status to approved.
 
         Args:
             job_id: Job UUID
@@ -526,8 +526,15 @@ class JobRestService:
         if job.quote_acceptance_date:
             raise ValueError("Quote has already been accepted")
 
+        # Guard clause - only allow acceptance from draft or awaiting_approval states
+        if job.status not in ["draft", "awaiting_approval"]:
+            raise ValueError(
+                f"Cannot accept quote when job status is '{job.status}'. Job must be in 'draft' or 'awaiting_approval' state."
+            )
+
         with transaction.atomic():
             job.quote_acceptance_date = datetime.now()
+            job.status = "approved"
             job.save()
 
             # Log the acceptance
@@ -535,15 +542,18 @@ class JobRestService:
                 job=job,
                 staff=user,
                 event_type="quote_accepted",
-                description="Quote accepted",
+                description="Quote accepted - status changed to approved",
             )
 
-        logger.info(f"Quote accepted for job {job.job_number} by {user.email}")
+        logger.info(
+            f"Quote accepted for job {job.job_number} by {user.email} - status changed to approved"
+        )
 
         return {
             "success": True,
             "job_id": str(job_id),
             "quote_acceptance_date": job.quote_acceptance_date.isoformat(),
+            "status": job.status,
             "message": "Quote accepted successfully",
         }
 


### PR DESCRIPTION
## Summary
- Accept quote now properly changes job status to 'approved'
- Added validation to only allow acceptance from valid states
- Returns updated status in response for frontend sync

## Problem
The "Accept Quote" button was not changing the job status to "Approved" as expected. It only set the quote acceptance date without updating the job status, and could be clicked from any state.

## Solution
Modified `JobRestService.accept_quote()` to:
1. Change job status to "approved" when accepting a quote
2. Only allow quote acceptance from "draft" or "awaiting_approval" states
3. Return the updated status in the response
4. Update the job event description to reflect the status change

## Test Plan
- [ ] Create a job in draft state with a quote
- [ ] Click "Accept Quote" button
- [ ] Verify job status changes to "approved"
- [ ] Verify quote_acceptance_date is set
- [ ] Try accepting quote from other states (should fail)
- [ ] Verify frontend button is disabled for invalid states

Fixes: https://trello.com/c/CFK9WFqi/122-quote-bug-1-accept-quote-not-working

🤖 Generated with [Claude Code](https://claude.ai/code)