### PR TITLE
fix: allow negative values for adjustment cost lines

### DIFF
--- a/apps/job/models/costing.py
+++ b/apps/job/models/costing.py
@@ -124,10 +124,7 @@ class CostLine(models.Model):
                 f"CostLine has negative quantity: {self.quantity} for {self.desc}"
             )
 
-        if self.unit_cost < 0:
-            raise ValidationError("Unit cost must be non-negative")
-        if self.unit_rev < 0:
-            raise ValidationError("Unit revenue must be non-negative")
+        # Allow negative values for adjustments, discounts, credits, etc.
 
     def _update_cost_set_summary(self) -> None:
         """Update cost set summary with aggregated data - PRESERVE existing data"""

--- a/apps/job/serializers/costing_serializer.py
+++ b/apps/job/serializers/costing_serializer.py
@@ -164,17 +164,15 @@ class CostLineCreateUpdateSerializer(serializers.ModelSerializer):
         return value
 
     def validate_unit_cost(self, value):
-        """Validate unit cost is non-negative"""
+        """Validate unit cost - allow negative values for adjustments"""
         logger.info(f"Validating unit_cost: {value} (type: {type(value)})")
-        if value < 0:
-            raise serializers.ValidationError("Unit cost must be non-negative")
+        # Allow negative values for adjustments, discounts, credits
         return value
 
     def validate_unit_rev(self, value):
-        """Validate unit revenue is non-negative"""
+        """Validate unit revenue - allow negative values for adjustments"""
         logger.info(f"Validating unit_rev: {value} (type: {type(value)})")
-        if value < 0:
-            raise serializers.ValidationError("Unit revenue must be non-negative")
+        # Allow negative values for adjustments, discounts, credits
         return value
 
     def save(self, **kwargs):


### PR DESCRIPTION
Allows negative values in cost lines to support discounts, credits, and adjustments. Fixes: https://trello.com/c/jNLcplD7/116-jm-not-invoicing-properly-from-total-revenue-amount-when-adjusted