### PR TITLE
feat(accounts): enhance staff management with dedicated create serializer

### DIFF
--- a/apps/accounts/__init__.py
+++ b/apps/accounts/__init__.py
@@ -12,9 +12,12 @@ try:
         from .models import Staff
         from .permissions import IsStaff
         from .serializers import (
+            BaseStaffSerializer,
             CustomTokenObtainPairSerializer,
             EmptySerializer,
+            GenericStaffMethodsMixin,
             KanbanStaffSerializer,
+            StaffCreateSerializer,
             StaffSerializer,
             TokenObtainPairResponseSerializer,
             TokenRefreshResponseSerializer,
@@ -32,12 +35,15 @@ except (ImportError, RuntimeError):
 
 __all__ = [
     "AccountsConfig",
+    "BaseStaffSerializer",
     "CustomTokenObtainPairSerializer",
     "EmptySerializer",
+    "GenericStaffMethodsMixin",
     "IsStaff",
     "KanbanStaffSerializer",
     "Staff",
     "StaffChangeForm",
+    "StaffCreateSerializer",
     "StaffCreationForm",
     "StaffManager",
     "StaffSerializer",

--- a/apps/accounts/views/staff_api.py
+++ b/apps/accounts/views/staff_api.py
@@ -1,17 +1,47 @@
 import logging
 
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import generics, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from apps.accounts.models import Staff
 from apps.accounts.permissions import IsStaff
-from apps.accounts.serializers import StaffSerializer
+from apps.accounts.serializers import StaffCreateSerializer, StaffSerializer
 
 logger = logging.getLogger(__name__)
 
 
+@extend_schema(
+    summary="List and create staff members",
+    description="API endpoint for listing all staff members and creating new staff members. "
+    "Supports multipart/form data for file uploads (e.g., profile pictures).",
+    tags=["Staff Management"],
+    examples=[
+        OpenApiExample(
+            "Create Staff Member",
+            value={
+                "email": "john.doe@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "preferred_name": "Johnny",
+                "password": "securepassword123",
+                "wage_rate": "25.50",
+                "is_staff": True,
+                "hours_mon": "8.00",
+                "hours_tue": "8.00",
+                "hours_wed": "8.00",
+                "hours_thu": "8.00",
+                "hours_fri": "8.00",
+                "hours_sat": "0.00",
+                "hours_sun": "0.00",
+            },
+            request_only=True,
+        ),
+    ],
+)
 class StaffListCreateAPIView(generics.ListCreateAPIView):
     """API endpoint for listing and creating staff members.
 
@@ -21,14 +51,62 @@ class StaffListCreateAPIView(generics.ListCreateAPIView):
     """
 
     queryset = Staff.objects.all()
-    serializer_class = StaffSerializer
     permission_classes = [IsAuthenticated, IsStaff]
     parser_classes = [MultiPartParser, FormParser]
 
     def get_queryset(self):
         return Staff.objects.all()
 
+    def get_serializer(self, *args, **kwargs):
+        if self.request.method == "POST":
+            return StaffCreateSerializer(*args, **kwargs)
+        return StaffSerializer(*args, **kwargs)
 
+    @extend_schema(
+        summary="Create a new staff member",
+        description="Create a new staff member with the provided details. "
+        "Supports multipart/form data for file uploads (e.g., profile pictures).",
+        tags=["Staff Management"],
+        request=StaffCreateSerializer,
+        responses={201: StaffSerializer},
+    )
+    def post(self, request, *args, **kwargs):
+        try:
+            logger.info(f"[StaffCreate] Method: {request.method}")
+            logger.info(f"[StaffCreate] Received data: {request.data}")
+            return super().post(request, *args, **kwargs)
+        except ValidationError as e:
+            logger.error(f"[StaffCreate] Error during staff creation: {str(e)}")
+            return Response(
+                {"error": f"Error during staff creation: {str(e)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+
+@extend_schema(
+    summary="Retrieve, update, or delete staff member",
+    description="API endpoint for retrieving, updating, and deleting individual staff members. "
+    "Supports GET (retrieve), PUT/PATCH (update), and DELETE operations. "
+    "Includes comprehensive logging for update operations and handles multipart/form data for file uploads.",
+    tags=["Staff Management"],
+    examples=[
+        OpenApiExample(
+            "Update Staff Member",
+            value={
+                "first_name": "Jane",
+                "last_name": "Smith",
+                "preferred_name": "Janie",
+                "wage_rate": "28.00",
+                "hours_mon": "7.50",
+                "hours_tue": "7.50",
+                "hours_wed": "7.50",
+                "hours_thu": "7.50",
+                "hours_fri": "7.50",
+            },
+            request_only=True,
+        ),
+    ],
+)
 class StaffRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAPIView):
     """API endpoint for retrieving, updating, and deleting individual staff members.
 


### PR DESCRIPTION
 ...and improved data handling

Introduce `GenericStaffMethodsMixin` to normalize empty string inputs for array and decimal fields in staff serializers. Create `BaseStaffSerializer` as a common base. Refactor `StaffSerializer` to use the base and explicitly define fields. Add `StaffCreateSerializer` for dedicated staff creation, handling password setting and using `StaffSerializer` for representation. Implement dynamic serializer selection in `StaffListCreateAPIView` to use the appropriate serializer for POST requests. Integrate `drf-spectacular` decorators for enhanced API documentation on staff endpoints, including examples and detailed descriptions. Add logging and error handling for staff creation.

These changes separate concerns between staff creation and update operations, improving clarity and maintainability. Centralizing data normalization prevents common data entry issues by converting empty strings to appropriate default values for lists and numbers. A dedicated create serializer ensures robust password handling. Enhanced API documentation makes the staff endpoints easier to understand and consume.
