### PR TITLE
refactor(staff_api): use get_serializer_class and improve validation …

### DIFF
--- a/apps/accounts/views/staff_api.py
+++ b/apps/accounts/views/staff_api.py
@@ -57,10 +57,10 @@ class StaffListCreateAPIView(generics.ListCreateAPIView):
     def get_queryset(self):
         return Staff.objects.all()
 
-    def get_serializer(self, *args, **kwargs):
+    def get_serializer_class(self):
         if self.request.method == "POST":
-            return StaffCreateSerializer(*args, **kwargs)
-        return StaffSerializer(*args, **kwargs)
+            return StaffCreateSerializer
+        return StaffSerializer
 
     @extend_schema(
         summary="Create a new staff member",
@@ -78,7 +78,7 @@ class StaffListCreateAPIView(generics.ListCreateAPIView):
         except ValidationError as e:
             logger.error(f"[StaffCreate] Error during staff creation: {str(e)}")
             return Response(
-                {"error": f"Error during staff creation: {str(e)}"},
+                e.detail,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 


### PR DESCRIPTION
…error response

The `get_serializer` method is renamed to `get_serializer_class` to align with Django REST Framework's standard practice for dynamically selecting serializers. This method should return the serializer class, not an instance. The error response for `ValidationError` is now `e.detail`, which provides a more structured and consistent error message format, improving API client usability.