### PR TITLE
feat: Always show Archived column on main kanban view

### DIFF
--- a/apps/job/services/kanban_categorization_service.py
+++ b/apps/job/services/kanban_categorization_service.py
@@ -73,6 +73,13 @@ class KanbanCategorizationService:
             color_theme="emerald",
             badge_color_class="bg-emerald-500",
         ),
+        "archived": KanbanColumn(
+            column_id="archived",
+            column_title="Archived",
+            status_key="archived",
+            color_theme="gray",
+            badge_color_class="bg-gray-500",
+        ),
     }
 
     # Status to column mapping for quick lookup - simplified 1:1 mapping
@@ -84,6 +91,7 @@ class KanbanCategorizationService:
         "in_progress": "in_progress",
         "unusual": "unusual",
         "recently_completed": "recently_completed",
+        "archived": "archived",
         # Legacy status mappings for backward compatibility (will be migrated)
         "quoting": "awaiting_approval",  # Legacy: map to awaiting_approval
         "accepted_quote": "approved",  # Legacy: map to approved
@@ -132,6 +140,7 @@ class KanbanCategorizationService:
             cls.COLUMN_STRUCTURE["in_progress"],
             cls.COLUMN_STRUCTURE["unusual"],
             cls.COLUMN_STRUCTURE["recently_completed"],
+            cls.COLUMN_STRUCTURE["archived"],
         ]
 
     @classmethod
@@ -193,7 +202,7 @@ class KanbanCategorizationService:
         Returns:
             True if status should be hidden from kanban
         """
-        hidden_statuses = {"special", "rejected", "archived"}
+        hidden_statuses = {"special", "rejected"}
         return status in hidden_statuses
 
     @classmethod


### PR DESCRIPTION
## 📝 Description

_One or two sentences summarizing what this PR does and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Brief bullet-list of the main changes (e.g. added `ChatMessageSerializer`, moved logic to `services/chat.py`, introduced pagination).
- …

## ✅ Checklist

**Django REST Framework**

- [ ] I used a `Serializer` for all request/response payloads
- [ ] Business logic is isolated in a service layer (`services/…`)
- [ ] Query optimizations (`select_related`/`prefetch_related`) applied where needed
- [ ] Pagination and filtering are configured for list endpoints
- [ ] Permissions and authentication classes are correct
- [ ] Error handling is uniform (all errors return JSON with a `detail` field)

**General**

- [ ] Code is type-hinted and passes `tox -e mypy`
- [ ] Formatted with Black/isort and linted with Flake8 (`tox -e lint`)
- [ ] Covered by new or updated unit tests
- [ ] Docstrings follow Google or NumPy style
