### PR TITLE
feat(client): make client name search case-insensitive

### DIFF
--- a/apps/client/services/client_rest_service.py
+++ b/apps/client/services/client_rest_service.py
@@ -433,7 +433,9 @@ class ClientRestService:
         output = DecimalField(max_digits=12, decimal_places=2)
 
         return (
-            Client.objects.filter(name__startswith=query)  # Index-friendly
+            Client.objects.filter(
+                name__istartswith=query
+            )  # Index-friendly, case insensitive
             .annotate(
                 last_invoice_date=Max("invoice__date"),
                 total_spend=Coalesce(


### PR DESCRIPTION
Updates the client search query to use `name__istartswith` instead of `name__startswith`. This change allows client names to be searched without regard to case, improving the user experience by making searches more flexible and forgiving. The previous `startswith` filter was case-sensitive, which could lead to missed results if the user's input did not exactly match the case of the stored client name.


