### PR TITLE
feat: include process app in backup/restore pipeline

### DIFF
--- a/apps/workflow/management/commands/backport_data_backup.py
+++ b/apps/workflow/management/commands/backport_data_backup.py
@@ -97,6 +97,9 @@ class Command(BaseCommand):
             "quoting.SupplierPriceList",
             "quoting.SupplierProduct",
             "quoting.ScrapeJob",
+            "process.Form",
+            "process.FormEntry",
+            "process.Procedure",
             "contenttypes",  # Django internal - needed for migrations
         ]
 

--- a/docs/backup-restore-process.md
+++ b/docs/backup-restore-process.md
@@ -257,22 +257,28 @@ SELECT 'workflow_job' as table_name, COUNT(*) as count FROM workflow_job
 UNION SELECT 'workflow_staff', COUNT(*) FROM workflow_staff
 UNION SELECT 'workflow_client', COUNT(*) FROM workflow_client
 UNION SELECT 'job_costset', COUNT(*) FROM job_costset
-UNION SELECT 'job_costline', COUNT(*) FROM job_costline;
+UNION SELECT 'job_costline', COUNT(*) FROM job_costline
+UNION SELECT 'process_form', COUNT(*) FROM process_form
+UNION SELECT 'process_form_entry', COUNT(*) FROM process_form_entry
+UNION SELECT 'process_procedure', COUNT(*) FROM process_procedure;
 "
 ```
 
 **Expected output (update with actual numbers):**
 
 ```
-+-------------------+-------+
-| table_name        | count |
-+-------------------+-------+
-| workflow_job      |  1054 |
-| workflow_staff    |    20 |
-| workflow_client   |  3739 |
-| job_costset       |  3162 |
-| job_costline      | 10334 |
-+-------------------+-------+
++---------------------+-------+
+| table_name          | count |
++---------------------+-------+
+| workflow_job        |  1054 |
+| workflow_staff      |    20 |
+| workflow_client     |  3739 |
+| job_costset         |  3162 |
+| job_costline        | 10334 |
+| process_form        |     5 |
+| process_form_entry  |   100 |
+| process_procedure   |    20 |
++---------------------+-------+
 ```
 
 #### Step 9: Apply Django Migrations

--- a/scripts/json_to_mysql.py
+++ b/scripts/json_to_mysql.py
@@ -62,6 +62,7 @@ class JSONToMySQLConverter:
             "delta_before",
             "delta_after",
             "delta_meta",
+            "form_schema",
         }
 
         # Mapping from Django model names to MySQL table names
@@ -88,6 +89,9 @@ class JSONToMySQLConverter:
             "purchasing.purchaseorder": "workflow_purchaseorder",
             "purchasing.purchaseorderline": "workflow_purchaseorderline",
             "purchasing.stock": "workflow_stock",
+            "process.form": "process_form",
+            "process.formentry": "process_form_entry",
+            "process.procedure": "process_procedure",
             "contenttypes.contenttype": "django_content_type",
             "migrations.migration": "django_migrations",
         }
@@ -179,6 +183,15 @@ class JSONToMySQLConverter:
                 "job": "job_id",
                 "source_parent_stock": "source_parent_stock_id",
                 "source_purchase_order_line": "source_purchase_order_line_id",
+            },
+            "process_form_entry": {
+                "form": "form_id",
+                "job": "job_id",
+                "staff": "staff_id",
+                "entered_by": "entered_by_id",
+            },
+            "process_procedure": {
+                "job": "job_id",
             },
         }
 


### PR DESCRIPTION
## Summary
- Added `process.Form`, `process.FormEntry`, and `process.Procedure` to the backup command's `INCLUDE_MODELS`
- Added model-to-table mappings, FK field mappings, and `form_schema` JSON field to `json_to_mysql.py`
- Updated restore verification docs to include process app table counts

## Test plan
- [ ] Run `python manage.py backport_data_backup` and verify process models appear in the JSON output
- [ ] Run `python scripts/json_to_mysql.py` on a backup containing process data and verify valid INSERT statements are generated
- [ ] Complete a full restore cycle and verify process_form, process_form_entry, and process_procedure tables have data

🤖 Generated with [Claude Code](https://claude.com/claude-code)